### PR TITLE
feat: token stock split

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,3 @@
 [submodule "lib/solady"]
 	path = lib/solady
 	url = https://github.com/Vectorized/solady
-[submodule "lib/solidity-datetime"]
-	path = lib/solidity-datetime
-	url = https://github.com/RollaProject/solidity-datetime

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "lib/solady"]
 	path = lib/solady
 	url = https://github.com/Vectorized/solady
+[submodule "lib/solidity-datetime"]
+	path = lib/solidity-datetime
+	url = https://github.com/RollaProject/solidity-datetime

--- a/src/BridgedERC20.sol
+++ b/src/BridgedERC20.sol
@@ -90,15 +90,21 @@ contract BridgedERC20 is ERC20, AccessControlDefaultAdminRules {
     /// ------------------ Setters ------------------ ///
 
     /// @notice Set token name
-    /// @dev Only callable by owner
-    function setName(string calldata name_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    /// @dev Only callable by owner or deployer
+    function setName(string calldata name_) external {
+        if (msg.sender != deployer) {
+            _checkRole(DEFAULT_ADMIN_ROLE);
+        }
         _name = name_;
         emit NameSet(name_);
     }
 
     /// @notice Set token symbol
-    /// @dev Only callable by owner
-    function setSymbol(string calldata symbol_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    /// @dev Only callable by owner or deployer
+    function setSymbol(string calldata symbol_) external {
+        if (msg.sender != deployer) {
+            _checkRole(DEFAULT_ADMIN_ROLE);
+        }
         _symbol = symbol_;
         emit SymbolSet(symbol_);
     }

--- a/src/TokenManager.sol
+++ b/src/TokenManager.sol
@@ -174,6 +174,7 @@ contract TokenManager is Ownable2Step {
             SplitInfo memory _split = splits[_parentToken];
             aggregateSupply = splitAmount(_split.multiple, _split.reverseSplit, _parentToken.totalSupply());
             while (address(_split.newToken) != address(token)) {
+                // slither-disable-next-line calls-loop
                 aggregateSupply += _split.newToken.totalSupply();
                 _split = splits[_split.newToken];
                 aggregateSupply = splitAmount(_split.multiple, _split.reverseSplit, aggregateSupply);

--- a/src/TokenManager.sol
+++ b/src/TokenManager.sol
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.19;
+
+import {ITransferRestrictor} from "./ITransferRestrictor.sol";
+import {BridgedERC20} from "./BridgedERC20.sol";
+
+import {EnumerableSet} from "openzeppelin-contracts/contracts/utils/structs/EnumerableSet.sol";
+import {Ownable2Step} from "openzeppelin-contracts/contracts/access/Ownable2Step.sol";
+
+contract TokenManager is Ownable2Step {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    /// ------------------ Types ------------------ ///
+
+    struct SplitInfo {
+        BridgedERC20 newToken;
+        uint8 multiple;
+        bool reverseSplit;
+    }
+
+    /// @dev Emitted when a split is performed
+    event Split(BridgedERC20 indexed legacyToken, BridgedERC20 indexed newToken, uint8 multiple, bool reverseSplit);
+
+    error TokenNotFound();
+    error InvalidMultiple();
+    error SplitNotFound();
+
+    /// ------------------ State ------------------ ///
+
+    /// @dev Suffix to append to new token names
+    string public nameSuffix = " - Dinari";
+
+    /// @dev Suffix to append to new token symbols
+    string public symbolSuffix = ".d";
+
+    /// @dev Transfer restrictor contract
+    ITransferRestrictor public transferRestrictor;
+
+    /// @dev Link to disclosures
+    string public disclosures = "";
+
+    /// @dev List of current tokens
+    EnumerableSet.AddressSet private _currentTokens;
+
+    /// @dev Mapping of legacy tokens to split information
+    mapping(BridgedERC20 => SplitInfo) public splits;
+
+    /// ------------------ Initialization ------------------ ///
+
+    /// @notice Initialize contract
+    /// @param transferRestrictor_ Contract to restrict transfers
+    constructor(ITransferRestrictor transferRestrictor_) {
+        transferRestrictor = transferRestrictor_;
+    }
+
+    /// ------------------ Getters ------------------ ///
+
+    /// @notice Get number of tokens
+    function getNumTokens() external view returns (uint256) {
+        return _currentTokens.length();
+    }
+
+    /// @notice Get token at index
+    function getTokenAt(uint256 index) external view returns (address) {
+        return _currentTokens.at(index);
+    }
+
+    /// @notice Get all tokens
+    /// @dev Returns a copy of the internal array
+    function getTokens() external view returns (address[] memory) {
+        return _currentTokens.values();
+    }
+
+    /// ------------------ Setters ------------------ ///
+
+    /// @notice Set suffix to append to new token names
+    /// @dev Only callable by owner
+    function setNameSuffix(string memory nameSuffix_) external onlyOwner {
+        nameSuffix = nameSuffix_;
+    }
+
+    /// @notice Set suffix to append to new token symbols
+    /// @dev Only callable by owner
+    function setSymbolSuffix(string memory symbolSuffix_) external onlyOwner {
+        symbolSuffix = symbolSuffix_;
+    }
+
+    /// @notice Set transfer restrictor contract
+    /// @dev Only callable by owner
+    function setTransferRestrictor(ITransferRestrictor transferRestrictor_) external onlyOwner {
+        transferRestrictor = transferRestrictor_;
+    }
+
+    /// @notice Set link to disclosures
+    /// @dev Only callable by owner
+    function setDisclosures(string memory disclosures_) external onlyOwner {
+        disclosures = disclosures_;
+    }
+
+    /// ------------------ Token Deployment ------------------ ///
+
+    /// @notice Deploy a new token
+    /// @param owner Owner of new token
+    /// @param name Name of new token, without suffix
+    /// @param symbol Symbol of new token, without suffix
+    function deployNewToken(address owner, string memory name, string memory symbol)
+        external
+        returns (BridgedERC20 newToken)
+    {
+        // Deploy new token
+        newToken = new BridgedERC20(
+            owner,
+            string.concat(name, nameSuffix),
+            string.concat(symbol, symbolSuffix),
+            disclosures,
+            transferRestrictor
+        );
+        // Add to list of tokens
+        _currentTokens.add(address(newToken));
+    }
+
+    /// ------------------ Split ------------------ ///
+
+    /// @notice Split a token
+    /// @param token Token to split
+    /// @param multiple Multiple to split by
+    /// @param reverseSplit Whether to perform a reverse split
+    // TODO: After split: no mint, no burn other than by this contract
+    // TODO: Is there a way to transfer ownership after config?
+    function split(BridgedERC20 token, uint8 multiple, bool reverseSplit) external returns (BridgedERC20 newToken) {
+        // Check if token is in list of tokens
+        if (!_currentTokens.contains(address(token))) revert TokenNotFound();
+        // Check if split multiple is valid
+        if (multiple == 0) revert InvalidMultiple();
+
+        // Remove legacy token from list of tokens
+        _currentTokens.remove(address(token));
+
+        // Get new token name
+        string memory name = token.name();
+        string memory symbol = token.symbol();
+
+        // Deploy new token
+        newToken = new BridgedERC20(
+            token.owner(),
+            name,
+            symbol,
+            disclosures,
+            transferRestrictor
+        );
+        // Add to list of tokens
+        _currentTokens.add(address(newToken));
+        // Map legacy token to split information
+        splits[token] = SplitInfo({newToken: newToken, multiple: multiple, reverseSplit: reverseSplit});
+
+        // Emit event
+        emit Split(token, newToken, multiple, reverseSplit);
+
+        // Rename legacy token
+        // TODO: replace suffixes with legacy versioning, possibly using dates lib
+        token.setName(string.concat(name, nameSuffix));
+        token.setSymbol(string.concat(symbol, symbolSuffix));
+    }
+
+    /// @notice Convert a token amount to current token after split
+    /// @param token Token to convert
+    /// @param amount Amount to convert
+    /// @return currentToken Current token minted to user
+    /// @return resultAmount Amount of current token minted to user
+    /// @dev Accounts for multiple splits and returns the current token
+    function convert(BridgedERC20 token, uint256 amount)
+        external
+        returns (BridgedERC20 currentToken, uint256 resultAmount)
+    {
+        // Check if token has been split
+        SplitInfo memory _split = splits[token];
+        if (address(_split.newToken) == address(0)) revert SplitNotFound();
+
+        // Apply splits
+        currentToken = _split.newToken;
+        resultAmount = splitAmount(_split.multiple, _split.reverseSplit, amount);
+        while (address(splits[currentToken].newToken) != address(0)) {
+            _split = splits[currentToken];
+            currentToken = _split.newToken;
+            resultAmount = splitAmount(_split.multiple, _split.reverseSplit, resultAmount);
+        }
+
+        // Transfer tokens
+        token.transferFrom(msg.sender, address(this), amount);
+        token.burn(amount);
+        currentToken.mint(msg.sender, resultAmount);
+    }
+
+    /// @notice Amount of token produced by a split
+    /// @param multiple Multiple to split by
+    /// @param reverseSplit Whether to perform a reverse split
+    /// @param amount Amount to split
+    function splitAmount(uint8 multiple, bool reverseSplit, uint256 amount) public pure returns (uint256) {
+        // Apply split
+        if (reverseSplit) {
+            return amount / multiple;
+        } else {
+            return amount * multiple;
+        }
+    }
+}

--- a/src/TokenManager.sol
+++ b/src/TokenManager.sol
@@ -6,9 +6,11 @@ import {BridgedERC20} from "./BridgedERC20.sol";
 
 import {EnumerableSet} from "openzeppelin-contracts/contracts/utils/structs/EnumerableSet.sol";
 import {Ownable2Step} from "openzeppelin-contracts/contracts/access/Ownable2Step.sol";
+import {Strings} from "openzeppelin-contracts/contracts/utils/Strings.sol";
 
 contract TokenManager is Ownable2Step {
     using EnumerableSet for EnumerableSet.AddressSet;
+    using Strings for uint256;
 
     /// ------------------ Types ------------------ ///
 
@@ -158,9 +160,9 @@ contract TokenManager is Ownable2Step {
         token.setSplit();
 
         // Rename legacy token
-        // TODO: replace suffixes with legacy versioning, possibly using dates lib
-        token.setName(string.concat(name, nameSuffix));
-        token.setSymbol(string.concat(symbol, symbolSuffix));
+        string memory timestamp = block.timestamp.toString();
+        token.setName(string.concat(name, " - pre", timestamp));
+        token.setSymbol(string.concat(symbol, ".p", timestamp));
     }
 
     /// @notice Convert a token amount to current token after split

--- a/src/TokenManager.sol
+++ b/src/TokenManager.sol
@@ -125,8 +125,6 @@ contract TokenManager is Ownable2Step {
     /// @param token Token to split
     /// @param multiple Multiple to split by
     /// @param reverseSplit Whether to perform a reverse split
-    // TODO: After split: no mint, no burn other than by this contract
-    // TODO: Is there a way to transfer ownership after config?
     function split(BridgedERC20 token, uint8 multiple, bool reverseSplit) external returns (BridgedERC20 newToken) {
         // Check if token is in list of tokens
         if (!_currentTokens.contains(address(token))) revert TokenNotFound();
@@ -136,7 +134,7 @@ contract TokenManager is Ownable2Step {
         // Remove legacy token from list of tokens
         _currentTokens.remove(address(token));
 
-        // Get new token name
+        // Get current token name
         string memory name = token.name();
         string memory symbol = token.symbol();
 
@@ -155,6 +153,9 @@ contract TokenManager is Ownable2Step {
 
         // Emit event
         emit Split(token, newToken, multiple, reverseSplit);
+
+        // Set split on legacy token
+        token.setSplit();
 
         // Rename legacy token
         // TODO: replace suffixes with legacy versioning, possibly using dates lib

--- a/src/TokenManager.sol
+++ b/src/TokenManager.sol
@@ -168,7 +168,7 @@ contract TokenManager is Ownable2Step {
         // Remove legacy token from list of tokens
         if (!_currentTokens.remove(address(token))) revert TokenNotFound();
         // Check if split exceeds max supply of type(uint256).max
-        aggregateSupply = _getSupplyExpansion(token, multiple, reverseSplit);
+        aggregateSupply = getSupplyExpansion(token, multiple, reverseSplit);
 
         // Get current token name
         string memory name = token.name();
@@ -201,9 +201,13 @@ contract TokenManager is Ownable2Step {
         token.setSymbol(string.concat(symbol, ".p", timestamp));
     }
 
+    /// @notice Calculate total aggregate supply after split
+    /// @param token Token to calculate supply expansion for
+    /// @param multiple Multiple to split by
+    /// @param reverseSplit Whether to perform a reverse split
     /// @dev Accounts for all splits and supply volume conversions
-    function _getSupplyExpansion(BridgedERC20 token, uint8 multiple, bool reverseSplit)
-        internal
+    function getSupplyExpansion(BridgedERC20 token, uint8 multiple, bool reverseSplit)
+        public
         view
         returns (uint256 aggregateSupply)
     {

--- a/test/BridgedERC20.t.sol
+++ b/test/BridgedERC20.t.sol
@@ -27,6 +27,19 @@ contract BridgedERC20Test is Test {
     }
 
     function testSetName(string calldata name) public {
+        vm.expectRevert(
+            bytes(
+                string.concat(
+                    "AccessControl: account ",
+                    Strings.toHexString(address(1)),
+                    " is missing role ",
+                    Strings.toHexString(uint256(token.DEFAULT_ADMIN_ROLE()), 32)
+                )
+            )
+        );
+        vm.prank(address(1));
+        token.setName(name);
+
         vm.expectEmit(true, true, true, true);
         emit NameSet(name);
         token.setName(name);
@@ -34,6 +47,19 @@ contract BridgedERC20Test is Test {
     }
 
     function testSetSymbol(string calldata symbol) public {
+        vm.expectRevert(
+            bytes(
+                string.concat(
+                    "AccessControl: account ",
+                    Strings.toHexString(address(1)),
+                    " is missing role ",
+                    Strings.toHexString(uint256(token.DEFAULT_ADMIN_ROLE()), 32)
+                )
+            )
+        );
+        vm.prank(address(1));
+        token.setSymbol(symbol);
+
         vm.expectEmit(true, true, true, true);
         emit SymbolSet(symbol);
         token.setSymbol(symbol);
@@ -52,6 +78,12 @@ contract BridgedERC20Test is Test {
         emit TransferRestrictorSet(ITransferRestrictor(account));
         token.setTransferRestrictor(ITransferRestrictor(account));
         assertEq(address(token.transferRestrictor()), account);
+    }
+
+    function testSetSplitReverts() public {
+        vm.expectRevert(BridgedERC20.Unauthorized.selector);
+        vm.prank(address(1));
+        token.setSplit();
     }
 
     function testMint() public {

--- a/test/BridgedERC20.t.sol
+++ b/test/BridgedERC20.t.sol
@@ -66,12 +66,13 @@ contract BridgedERC20Test is Test {
             bytes(
                 string.concat(
                     "AccessControl: account ",
-                    Strings.toHexString(address(this)),
+                    Strings.toHexString(address(1)),
                     " is missing role ",
                     Strings.toHexString(uint256(token.MINTER_ROLE()), 32)
                 )
             )
         );
+        vm.prank(address(1));
         token.mint(address(1), 1e18);
     }
 
@@ -91,7 +92,7 @@ contract BridgedERC20Test is Test {
         token.grantRole(token.BURNER_ROLE(), address(2));
         token.mint(address(1), 1e18);
         token.mint(address(2), 1e18);
-        vm.expectRevert(BridgedERC20.UnauthorizedOperation.selector);
+        vm.expectRevert(BridgedERC20.Unauthorized.selector);
         vm.prank(address(1));
         token.transfer(address(0), 0.1e18);
 

--- a/test/TokenManager.t.sol
+++ b/test/TokenManager.t.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import "forge-std/Test.sol";
+import "prb-math/Common.sol" as PrbMath;
+import "../src/TokenManager.sol";
+import {TransferRestrictor} from "../src/TransferRestrictor.sol";
+
+contract TokenManagerTest is Test {
+    event NameSuffixSet(string nameSuffix);
+    event SymbolSuffixSet(string symbolSuffix);
+    event TransferRestrictorSet(ITransferRestrictor transferRestrictor);
+    event DisclosuresSet(string disclosures);
+    event NewToken(BridgedERC20 indexed token);
+    event Split(BridgedERC20 indexed legacyToken, BridgedERC20 indexed newToken, uint8 multiple, bool reverseSplit);
+
+    TokenManager tokenManager;
+    TransferRestrictor restrictor;
+
+    BridgedERC20 token1;
+
+    address user = address(2);
+
+    function setUp() public {
+        restrictor = new TransferRestrictor(address(this));
+        tokenManager = new TokenManager(restrictor);
+
+        // token1 = new BridgedERC20(address(this), "Token1", "TKN1", "example.com", restrictor);
+        token1 = tokenManager.deployNewToken(address(this), "Token1", "TKN1");
+        token1.grantRole(token1.MINTER_ROLE(), address(this));
+    }
+
+    function overflowChecker(uint256 a, uint256 b) internal pure returns (bool) {
+        if (a == 0 || b == 0) {
+            return false;
+        }
+        uint256 c;
+        unchecked {
+            c = a * b;
+        }
+        return c / a != b;
+    }
+
+    function testAdministration() public {
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(address(1));
+        tokenManager.setNameSuffix(" - Dinero");
+
+        vm.expectEmit(true, true, true, true);
+        emit NameSuffixSet(" - Dinero");
+        tokenManager.setNameSuffix(" - Dinero");
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(address(1));
+        tokenManager.setSymbolSuffix(".x");
+
+        vm.expectEmit(true, true, true, true);
+        emit SymbolSuffixSet(".x");
+        tokenManager.setSymbolSuffix(".x");
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(address(1));
+        tokenManager.setTransferRestrictor(ITransferRestrictor(address(1)));
+
+        vm.expectEmit(true, true, true, true);
+        emit TransferRestrictorSet(ITransferRestrictor(address(1)));
+        tokenManager.setTransferRestrictor(ITransferRestrictor(address(1)));
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(address(1));
+        tokenManager.setDisclosures("example.com");
+
+        vm.expectEmit(true, true, true, true);
+        emit DisclosuresSet("example.com");
+        tokenManager.setDisclosures("example.com");
+    }
+
+    function testDeployNewToken() public {
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(address(1));
+        tokenManager.deployNewToken(address(1), "Token", "TKN");
+
+        BridgedERC20 newToken = tokenManager.deployNewToken(address(1), "Token", "TKN");
+        assertEq(newToken.owner(), address(1));
+        assertEq(newToken.name(), "Token - Dinari");
+        assertEq(newToken.symbol(), "TKN.d");
+        assertEq(newToken.disclosures(), "");
+        assertEq(address(newToken.transferRestrictor()), address(restrictor));
+        assertEq(tokenManager.getNumTokens(), 2);
+        assertEq(address(tokenManager.getTokenAt(1)), address(newToken));
+        assertTrue(tokenManager.isCurrentToken(address(newToken)));
+
+        address[] memory tokens = tokenManager.getTokens();
+        assertEq(tokens.length, 2);
+        assertEq(tokens[0], address(token1));
+        assertEq(tokens[1], address(newToken));
+    }
+
+    function testSplit(uint256 supply, uint8 multiple, bool reverse) public {
+        // mint supply to user
+        token1.mint(user, supply);
+
+        if (multiple < 2) {
+            vm.expectRevert(TokenManager.InvalidMultiple.selector);
+            tokenManager.split(token1, multiple, reverse);
+        } else if (!reverse && overflowChecker(supply, multiple)) {
+            vm.expectRevert(stdError.arithmeticError);
+            tokenManager.split(token1, multiple, reverse);
+        } else {
+            vm.expectEmit(true, false, true, true);
+            emit Split(token1, BridgedERC20(address(0)), multiple, reverse);
+            BridgedERC20 newToken = tokenManager.split(token1, multiple, reverse);
+            assertEq(newToken.owner(), token1.owner());
+            assertEq(newToken.name(), "Token1 - Dinari");
+            assertEq(newToken.symbol(), "TKN1.d");
+            assertEq(newToken.disclosures(), "");
+            assertEq(address(newToken.transferRestrictor()), address(restrictor));
+            assertEq(token1.name(), "Token1 - Dinari - pre1");
+            assertEq(token1.symbol(), "TKN1.d.p1");
+            assertEq(tokenManager.getNumTokens(), 1);
+            assertEq(address(tokenManager.getTokenAt(0)), address(newToken));
+            assertTrue(tokenManager.isCurrentToken(address(newToken)));
+            assertFalse(tokenManager.isCurrentToken(address(token1)));
+        }
+    }
+
+    function testSplitReverts() public {
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(address(1));
+        tokenManager.split(token1, 2, false);
+
+        vm.expectRevert(TokenManager.TokenNotFound.selector);
+        tokenManager.split(BridgedERC20(address(1)), 2, false);
+    }
+
+    function testConvert(uint8 multiple, bool reverse, uint256 amount) public {
+        vm.assume(multiple > 1);
+        vm.assume(reverse || !overflowChecker(amount, uint256(multiple) * multiple));
+
+        // mint amount to user
+        token1.mint(user, amount);
+        // user approves token manager
+        vm.prank(user);
+        token1.approve(address(tokenManager), amount);
+
+        // split token
+        BridgedERC20 newToken = tokenManager.split(token1, multiple, reverse);
+        // split token again
+        BridgedERC20 newToken2 = tokenManager.split(newToken, multiple, reverse);
+
+        // convert amount
+        vm.prank(user);
+        (BridgedERC20 currentToken, uint256 convertedAmount) = tokenManager.convert(token1, amount);
+        assertEq(address(currentToken), address(newToken2));
+        if (reverse) {
+            assertEq(convertedAmount, (amount / multiple) / multiple);
+        } else {
+            assertEq(convertedAmount, amount * multiple * multiple);
+        }
+        assertEq(token1.balanceOf(user), 0);
+        assertEq(newToken2.balanceOf(user), convertedAmount);
+    }
+
+    function testConvertSplitNotFoundReverts() public {
+        vm.expectRevert(TokenManager.SplitNotFound.selector);
+        tokenManager.convert(BridgedERC20(address(1)), 1);
+    }
+}

--- a/test/TokenManager.t.sol
+++ b/test/TokenManager.t.sol
@@ -121,6 +121,14 @@ contract TokenManagerTest is Test {
             assertEq(address(tokenManager.getTokenAt(0)), address(newToken));
             assertTrue(tokenManager.isCurrentToken(address(newToken)));
             assertFalse(tokenManager.isCurrentToken(address(token1)));
+
+            // split restrictions
+            vm.expectRevert(BridgedERC20.TokenSplit.selector);
+            token1.mint(user, 1);
+
+            vm.expectRevert(BridgedERC20.TokenSplit.selector);
+            vm.prank(user);
+            token1.burn(1);
         }
     }
 


### PR DESCRIPTION
This introduces a token factory that handles initial deployments and splits. Minimal changes are made to to the token to lock down minting and burning after a call to `split`. `split` deploys a new token. Holders of the legacy token can call `convert` on token factory to burn legacy token for new token according to the (aggregate) split multiple.
