### PR TITLE
feat: add order placement methods to interface

### DIFF
--- a/.gas-report
+++ b/.gas-report
@@ -6,9 +6,9 @@
 | ASSETTOKEN_ROLE                                                                           | 645             | 773    | 667    | 5167   | 42      |
 | OPERATOR_ROLE                                                                             | 666             | 668    | 666    | 688    | 40      |
 | PAYMENTTOKEN_ROLE                                                                         | 646             | 760    | 646    | 5146   | 42      |
-| cancelOrder                                                                               | 9332            | 41046  | 51084  | 73296  | 5       |
-| fillOrder                                                                                 | 4306            | 42823  | 30783  | 107947 | 11      |
-| getFeesForOrder                                                                           | 1087            | 8513   | 4566   | 22148  | 41      |
+| cancelOrder                                                                               | 9332            | 32559  | 29764  | 51970  | 5       |
+| fillOrder                                                                                 | 5812            | 40374  | 30783  | 90100  | 10      |
+| getFeesForOrder                                                                           | 1087            | 8484   | 4566   | 22148  | 41      |
 | getFlatFeeForOrder                                                                        | 961             | 2465   | 3218   | 3218   | 3       |
 | getInputValueForOrderValue                                                                | 1100            | 5678   | 5678   | 10257  | 2       |
 | getOrderEscrow                                                                            | 938             | 938    | 938    | 938    | 1       |
@@ -20,19 +20,19 @@
 | grantRole                                                                                 | 27958           | 27993  | 28003  | 28003  | 120     |
 | hasRole                                                                                   | 3120            | 3120   | 3120   | 3120   | 2       |
 | isOrderActive                                                                             | 900             | 928    | 943    | 943    | 3       |
-| multicall                                                                                 | 190984          | 220065 | 224766 | 244446 | 3       |
+| multicall                                                                                 | 190984          | 220038 | 224684 | 244446 | 3       |
 | numOpenOrders                                                                             | 743             | 751    | 743    | 765    | 5       |
 | orderFees                                                                                 | 832             | 832    | 832    | 832    | 1       |
 | ordersPaused                                                                              | 788             | 788    | 788    | 788    | 1       |
 | owner                                                                                     | 820             | 820    | 820    | 820    | 1       |
 | requestCancel                                                                             | 2050            | 4765   | 3729   | 8516   | 3       |
-| requestOrder                                                                              | 6052            | 113394 | 130413 | 175023 | 27      |
-| returnEscrow                                                                              | 23998           | 23998  | 23998  | 23998  | 1       |
+| requestOrder                                                                              | 6052            | 114084 | 130195 | 175023 | 27      |
+| returnEscrow                                                                              | 1255            | 1255   | 1255   | 1255   | 1       |
 | selfPermit                                                                                | 56677           | 59677  | 59177  | 63677  | 4       |
 | setOrderFees                                                                              | 11041           | 12430  | 12439  | 13801  | 4       |
 | setOrdersPaused                                                                           | 10934           | 12334  | 12334  | 13734  | 2       |
 | setTreasury                                                                               | 7714            | 10796  | 10796  | 13879  | 2       |
-| takeEscrow                                                                                | 4421            | 26057  | 33123  | 33123  | 5       |
+| takeEscrow                                                                                | 26499           | 31798  | 33123  | 33123  | 5       |
 | treasury                                                                                  | 788             | 788    | 788    | 788    | 1       |
 | upgradeToAndCall                                                                          | 32709           | 32709  | 32709  | 32709  | 1       |
 | lib/solady/test/utils/mocks/MockERC20.sol:MockERC20 contract |                 |       |        |       |         |
@@ -43,14 +43,14 @@
 | DOMAIN_SEPARATOR                                             | 1244            | 1244  | 1244   | 1244  | 26      |
 | allowance                                                    | 678             | 678   | 678    | 678   | 1       |
 | approve                                                      | 24403           | 24403 | 24403  | 24403 | 3       |
-| balanceOf                                                    | 599             | 1023  | 599    | 2599  | 33      |
+| balanceOf                                                    | 599             | 1099  | 599    | 2599  | 32      |
 | decimals                                                     | 335             | 1092  | 335    | 2335  | 66      |
-| increaseAllowance                                            | 24548           | 24548 | 24548  | 24548 | 19      |
+| increaseAllowance                                            | 4648            | 23500 | 24548  | 24548 | 19      |
 | mint                                                         | 46581           | 46581 | 46581  | 46581 | 25      |
 | nonces                                                       | 533             | 1421  | 533    | 2533  | 9       |
 | permit                                                       | 51238           | 51238 | 51238  | 51238 | 4       |
-| transfer                                                     | 18235           | 22308 | 24793  | 24793 | 16      |
-| transferFrom                                                 | 2757            | 19914 | 20277  | 30008 | 20      |
+| transfer                                                     | 18235           | 22009 | 22793  | 24793 | 15      |
+| transferFrom                                                 | 18677           | 20811 | 20277  | 30008 | 19      |
 | src/TransferRestrictor.sol:TransferRestrictor contract |                 |       |        |       |         |
 |--------------------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                                        | Deployment Size |       |        |       |         |
@@ -105,9 +105,9 @@
 | ASSETTOKEN_ROLE                                       | 284             | 284    | 284    | 284    | 28      |
 | OPERATOR_ROLE                                         | 283             | 283    | 283    | 283    | 26      |
 | PAYMENTTOKEN_ROLE                                     | 263             | 263    | 263    | 263    | 28      |
-| cancelOrder                                           | 15498           | 33117  | 33117  | 50736  | 2       |
-| fillOrder                                             | 7380            | 55004  | 52557  | 107525 | 4       |
-| getFeesForOrder                                       | 695             | 5742   | 4174   | 17256  | 29      |
+| cancelOrder                                           | 15498           | 22459  | 22459  | 29421  | 2       |
+| fillOrder                                             | 7380            | 37498  | 15351  | 89763  | 3       |
+| getFeesForOrder                                       | 695             | 5698   | 4174   | 17256  | 29      |
 | getInputValueForOrderValue                            | 705             | 5283   | 5283   | 9862   | 2       |
 | getOrderIdFromOrderRequest                            | 1229            | 1229   | 1229   | 1229   | 6       |
 | getRemainingOrder                                     | 534             | 534    | 534    | 534    | 2       |
@@ -116,13 +116,13 @@
 | hasRole                                               | 2731            | 2731   | 2731   | 2731   | 2       |
 | initialize                                            | 23299           | 155493 | 165270 | 165270 | 29      |
 | isOrderActive                                         | 514             | 514    | 514    | 514    | 1       |
-| multicall                                             | 190472          | 216553 | 219754 | 239434 | 3       |
+| multicall                                             | 190472          | 216526 | 219672 | 239434 | 3       |
 | numOpenOrders                                         | 382             | 382    | 382    | 382    | 2       |
 | orderFees                                             | 449             | 449    | 449    | 449    | 1       |
 | ordersPaused                                          | 405             | 405    | 405    | 405    | 1       |
 | owner                                                 | 437             | 437    | 437    | 437    | 1       |
 | requestCancel                                         | 1636            | 2852   | 3319   | 3602   | 3       |
-| requestOrder                                          | 5638            | 98904  | 133234 | 174613 | 14      |
+| requestOrder                                          | 5638            | 98206  | 129834 | 174613 | 14      |
 | selfPermit                                            | 56267           | 58142  | 58767  | 58767  | 4       |
 | setOrderFees                                          | 7135            | 8323   | 8918   | 8918   | 3       |
 | setOrdersPaused                                       | 6051            | 7451   | 7451   | 8851   | 2       |
@@ -137,16 +137,16 @@
 | ASSETTOKEN_ROLE                                         | 306             | 306    | 306    | 306    | 5       |
 | OPERATOR_ROLE                                           | 305             | 305    | 305    | 305    | 5       |
 | PAYMENTTOKEN_ROLE                                       | 263             | 263    | 263    | 263    | 5       |
-| cancelOrder                                             | 7125            | 28936  | 28936  | 50748  | 2       |
-| fillOrder                                               | 3880            | 40519  | 40519  | 77159  | 2       |
-| getFeesForOrder                                         | 4174            | 10182  | 9424   | 17256  | 10      |
+| cancelOrder                                             | 7125            | 29040  | 29040  | 50955  | 2       |
+| fillOrder                                               | 5386            | 41125  | 41125  | 76865  | 2       |
+| getFeesForOrder                                         | 4174            | 10182  | 9383   | 17256  | 10      |
 | getOrderEscrow                                          | 552             | 552    | 552    | 552    | 1       |
 | getOrderIdFromOrderRequest                              | 1251            | 1251   | 1251   | 1251   | 4       |
 | grantRole                                               | 27572           | 27572  | 27572  | 27572  | 15      |
 | initialize                                              | 165270          | 165270 | 165270 | 165270 | 5       |
-| requestOrder                                            | 147815          | 148494 | 147880 | 149480 | 5       |
-| returnEscrow                                            | 23665           | 23665  | 23665  | 23665  | 1       |
-| takeEscrow                                              | 4001            | 25657  | 32707  | 32707  | 5       |
+| requestOrder                                            | 147815          | 154146 | 149480 | 162012 | 5       |
+| returnEscrow                                            | 835             | 835    | 835    | 835    | 1       |
+| takeEscrow                                              | 26166           | 31398  | 32707  | 32707  | 5       |
 | src/issuer/LimitBuyIssuer.sol:LimitBuyIssuer contract |                 |        |        |        |         |
 |-------------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                       | Deployment Size |        |        |        |         |
@@ -155,12 +155,12 @@
 | ASSETTOKEN_ROLE                                       | 284             | 284    | 284    | 284    | 2       |
 | OPERATOR_ROLE                                         | 283             | 283    | 283    | 283    | 2       |
 | PAYMENTTOKEN_ROLE                                     | 263             | 263    | 263    | 263    | 2       |
-| fillOrder                                             | 10457           | 10457  | 10457  | 10457  | 1       |
-| getFeesForOrder                                       | 13972           | 14323  | 14323  | 14674  | 2       |
+| fillOrder                                             | 30357           | 30357  | 30357  | 30357  | 1       |
+| getFeesForOrder                                       | 13972           | 14364  | 14364  | 14756  | 2       |
 | getOrderIdFromOrderRequest                            | 1229            | 1229   | 1229   | 1229   | 2       |
 | grantRole                                             | 27617           | 27617  | 27617  | 27617  | 6       |
 | initialize                                            | 165270          | 165270 | 165270 | 165270 | 2       |
-| requestOrder                                          | 17147           | 73616  | 73616  | 130085 | 2       |
+| requestOrder                                          | 17147           | 73649  | 73649  | 130151 | 2       |
 | src/issuer/LimitSellProcessor.sol:LimitSellProcessor contract |                 |        |        |        |         |
 |---------------------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                               | Deployment Size |        |        |        |         |
@@ -185,7 +185,7 @@
 | Function Name                               | min             | avg   | median | max   | # calls |
 | flatFeeForOrder                             | 1083            | 3865  | 1790   | 8290  | 68      |
 | perOrderFee                                 | 343             | 1343  | 1343   | 2343  | 2       |
-| percentageFeeForValue                       | 640             | 1224  | 640    | 2722  | 60      |
+| percentageFeeForValue                       | 640             | 1232  | 640    | 2722  | 59      |
 | percentageFeeRate                           | 369             | 369   | 369    | 369   | 1       |
 | recoverInputValueFromRemaining              | 760             | 760   | 760    | 760   | 2       |
 | setFees                                     | 9258            | 11658 | 11658  | 14058 | 2       |
@@ -197,8 +197,8 @@
 | ASSETTOKEN_ROLE                                               | 262             | 262    | 262    | 262    | 5       |
 | OPERATOR_ROLE                                                 | 283             | 283    | 283    | 283    | 5       |
 | PAYMENTTOKEN_ROLE                                             | 307             | 307    | 307    | 307    | 5       |
-| cancelOrder                                                   | 72949           | 72949  | 72949  | 72949  | 1       |
-| fillOrder                                                     | 7380            | 40093  | 53644  | 59255  | 3       |
+| cancelOrder                                                   | 51628           | 51628  | 51628  | 51628  | 1       |
+| fillOrder                                                     | 7380            | 46598  | 53579  | 78835  | 3       |
 | getFlatFeeForOrder                                            | 575             | 2079   | 2832   | 2832   | 3       |
 | getOrderId                                                    | 1665            | 1665   | 1665   | 1665   | 1       |
 | getOrderIdFromOrderRequest                                    | 1229            | 1229   | 1229   | 1229   | 4       |
@@ -229,6 +229,6 @@
 | decimals                                            | 246             | 246   | 246    | 246   | 2       |
 | grantRole                                           | 25610           | 26785 | 27610  | 27610 | 80      |
 | increaseAllowance                                   | 24489           | 24489 | 24489  | 24489 | 6       |
-| mint                                                | 47034           | 48811 | 49034  | 49034 | 9       |
+| mint                                                | 47034           | 48784 | 49034  | 49034 | 8       |
 | transfer                                            | 19478           | 19478 | 19478  | 19478 | 1       |
 | transferFrom                                        | 26648           | 27714 | 28248  | 28248 | 6       |

--- a/src/issuer/IOrderBridge.sol
+++ b/src/issuer/IOrderBridge.sol
@@ -52,6 +52,20 @@ interface IOrderBridge {
         uint256 fee;
     }
 
+    // Specification for an order
+    struct OrderRequest {
+        // Recipient of order fills
+        address recipient;
+        // Bridged asset token
+        address assetToken;
+        // Payment token
+        address paymentToken;
+        // Amount of incoming order token to be used for fills
+        uint256 quantityIn;
+        // price enquiry for the request
+        uint256 price;
+    }
+
     /// @dev Fully specifies order details and salt used to generate order ID
     event OrderRequested(bytes32 indexed id, address indexed recipient, Order order, bytes32 salt);
     /// @dev Emitted for each fill
@@ -84,4 +98,35 @@ interface IOrderBridge {
     /// @notice Get total received for order
     /// @param id Order ID to check
     function getTotalReceived(bytes32 id) external view returns (uint256);
+
+    /// ------------------ Actions ------------------ ///
+
+    /// @notice Request an order
+    /// @param orderRequest Order request to submit
+    /// @param salt Salt used to generate unique order ID
+    /// @dev Emits OrderRequested event to be sent to fulfillment service (operator)
+    function requestOrder(OrderRequest calldata orderRequest, bytes32 salt) external;
+
+    /// @notice Fill an order
+    /// @param orderRequest Order request to fill
+    /// @param salt Salt used to generate unique order ID
+    /// @param fillAmount Amount of order token to fill
+    /// @param receivedAmount Amount of received token
+    /// @dev Only callable by operator
+    function fillOrder(OrderRequest calldata orderRequest, bytes32 salt, uint256 fillAmount, uint256 receivedAmount)
+        external;
+
+    /// @notice Request to cancel an order
+    /// @param orderRequest Order request to cancel
+    /// @param salt Salt used to generate unique order ID
+    /// @dev Only callable by initial order requester
+    /// @dev Emits CancelRequested event to be sent to fulfillment service (operator)
+    function requestCancel(OrderRequest calldata orderRequest, bytes32 salt) external;
+
+    /// @notice Cancel an order
+    /// @param orderRequest Order request to cancel
+    /// @param salt Salt used to generate unique order ID
+    /// @param reason Reason for cancellation
+    /// @dev Only callable by operator
+    function cancelOrder(OrderRequest calldata orderRequest, bytes32 salt, string calldata reason) external;
 }

--- a/src/issuer/OrderProcessor.sol
+++ b/src/issuer/OrderProcessor.sol
@@ -43,20 +43,6 @@ abstract contract OrderProcessor is
 {
     /// ------------------ Types ------------------ ///
 
-    // Specification for an order
-    struct OrderRequest {
-        // Recipient of order fills
-        address recipient;
-        // Bridged asset token
-        address assetToken;
-        // Payment token
-        address paymentToken;
-        // Amount of incoming order token to be used for fills
-        uint256 quantityIn;
-        // price enquiry for the request
-        uint256 price;
-    }
-
     // Order state accounting variables
     struct OrderState {
         // Account that requested the order
@@ -237,10 +223,7 @@ abstract contract OrderProcessor is
 
     /// ------------------ Order Lifecycle ------------------ ///
 
-    /// @notice Request an order
-    /// @param orderRequest Order request to submit
-    /// @param salt Salt used to generate unique order ID
-    /// @dev Emits OrderRequested event to be sent to fulfillment service (operator)
+    /// @inheritdoc IOrderBridge
     function requestOrder(OrderRequest calldata orderRequest, bytes32 salt) public nonReentrant whenOrdersNotPaused {
         // Reject spam orders
         if (orderRequest.quantityIn == 0) revert ZeroValue();
@@ -263,12 +246,7 @@ abstract contract OrderProcessor is
         _numOpenOrders++;
     }
 
-    /// @notice Fill an order
-    /// @param orderRequest Order request to fill
-    /// @param salt Salt used to generate unique order ID
-    /// @param fillAmount Amount of order token to fill
-    /// @param receivedAmount Amount of received token
-    /// @dev Only callable by operator
+    /// @inheritdoc IOrderBridge
     function fillOrder(OrderRequest calldata orderRequest, bytes32 salt, uint256 fillAmount, uint256 receivedAmount)
         external
         nonReentrant
@@ -305,11 +283,7 @@ abstract contract OrderProcessor is
         _fillOrderAccounting(orderRequest, orderId, orderState, fillAmount, receivedAmount);
     }
 
-    /// @notice Request to cancel an order
-    /// @param orderRequest Order request to cancel
-    /// @param salt Salt used to generate unique order ID
-    /// @dev Only callable by initial order requester
-    /// @dev Emits CancelRequested event to be sent to fulfillment service (operator)
+    /// @inheritdoc IOrderBridge
     function requestCancel(OrderRequest calldata orderRequest, bytes32 salt) external {
         bytes32 orderId = getOrderIdFromOrderRequest(orderRequest, salt);
         address requester = _orders[orderId].requester;
@@ -322,11 +296,7 @@ abstract contract OrderProcessor is
         emit CancelRequested(orderId, orderRequest.recipient);
     }
 
-    /// @notice Cancel an order
-    /// @param orderRequest Order request to cancel
-    /// @param salt Salt used to generate unique order ID
-    /// @param reason Reason for cancellation
-    /// @dev Only callable by operator
+    /// @inheritdoc IOrderBridge
     function cancelOrder(OrderRequest calldata orderRequest, bytes32 salt, string calldata reason)
         external
         nonReentrant

--- a/test/BuyOrderIssuer.t.sol
+++ b/test/BuyOrderIssuer.t.sol
@@ -35,7 +35,7 @@ contract BuyOrderIssuerTest is Test {
     address constant treasury = address(4);
 
     bytes32 constant salt = 0x0000000000000000000000000000000000000000000000000000000000000001;
-    OrderProcessor.OrderRequest dummyOrder;
+    IOrderBridge.OrderRequest dummyOrder;
     uint256 dummyOrderFees;
     IOrderBridge.Order dummyOrderBridgeData;
 
@@ -63,7 +63,7 @@ contract BuyOrderIssuerTest is Test {
         issuer.grantRole(issuer.ASSETTOKEN_ROLE(), address(token));
         issuer.grantRole(issuer.OPERATOR_ROLE(), operator);
 
-        dummyOrder = OrderProcessor.OrderRequest({
+        dummyOrder = IOrderBridge.OrderRequest({
             recipient: user,
             assetToken: address(token),
             paymentToken: address(paymentToken),
@@ -181,7 +181,7 @@ contract BuyOrderIssuerTest is Test {
     }
 
     function testRequestOrder(uint256 quantityIn) public {
-        OrderProcessor.OrderRequest memory order = OrderProcessor.OrderRequest({
+        IOrderBridge.OrderRequest memory order = IOrderBridge.OrderRequest({
             recipient: user,
             assetToken: address(token),
             paymentToken: address(paymentToken),
@@ -250,7 +250,7 @@ contract BuyOrderIssuerTest is Test {
     function testRequestOrderUnsupportedPaymentReverts(address tryPaymentToken) public {
         vm.assume(!issuer.hasRole(issuer.PAYMENTTOKEN_ROLE(), tryPaymentToken));
 
-        OrderProcessor.OrderRequest memory order = dummyOrder;
+        IOrderBridge.OrderRequest memory order = dummyOrder;
         order.paymentToken = tryPaymentToken;
 
         vm.expectRevert(
@@ -270,7 +270,7 @@ contract BuyOrderIssuerTest is Test {
     function testRequestOrderUnsupportedAssetReverts(address tryAssetToken) public {
         vm.assume(!issuer.hasRole(issuer.ASSETTOKEN_ROLE(), tryAssetToken));
 
-        OrderProcessor.OrderRequest memory order = dummyOrder;
+        IOrderBridge.OrderRequest memory order = dummyOrder;
         order.assetToken = tryAssetToken;
 
         vm.expectRevert(
@@ -341,7 +341,7 @@ contract BuyOrderIssuerTest is Test {
     }
 
     function testFillOrder(uint256 orderAmount, uint256 fillAmount, uint256 receivedAmount) public {
-        OrderProcessor.OrderRequest memory order = dummyOrder;
+        IOrderBridge.OrderRequest memory order = dummyOrder;
         order.quantityIn = orderAmount;
         (uint256 flatFee, uint256 percentageFee) = issuer.getFeesForOrder(order.paymentToken, order.quantityIn);
         uint256 fees = flatFee + percentageFee;
@@ -388,7 +388,7 @@ contract BuyOrderIssuerTest is Test {
     }
 
     function testFulfillOrder(uint256 orderAmount, uint256 receivedAmount) public {
-        OrderProcessor.OrderRequest memory order = dummyOrder;
+        IOrderBridge.OrderRequest memory order = dummyOrder;
         order.quantityIn = orderAmount;
         (uint256 flatFee, uint256 percentageFee) = issuer.getFeesForOrder(order.paymentToken, order.quantityIn);
         uint256 fees = flatFee + percentageFee;
@@ -465,7 +465,7 @@ contract BuyOrderIssuerTest is Test {
     function testCancelOrder(uint256 inputAmount, uint256 fillAmount, string calldata reason) public {
         vm.assume(inputAmount > 0);
 
-        OrderProcessor.OrderRequest memory order = dummyOrder;
+        IOrderBridge.OrderRequest memory order = dummyOrder;
         order.quantityIn = inputAmount;
         (uint256 flatFee, uint256 percentageFee) = issuer.getFeesForOrder(order.paymentToken, order.quantityIn);
         uint256 fees = flatFee + percentageFee;

--- a/test/DirectBuyIssuer.t.sol
+++ b/test/DirectBuyIssuer.t.sol
@@ -30,7 +30,7 @@ contract DirectBuyIssuerTest is Test {
     address constant treasury = address(4);
 
     bytes32 constant salt = 0x0000000000000000000000000000000000000000000000000000000000000001;
-    OrderProcessor.OrderRequest dummyOrder;
+    IOrderBridge.OrderRequest dummyOrder;
     uint256 dummyOrderFees;
     IOrderBridge.Order dummyOrderBridgeData;
 
@@ -57,7 +57,7 @@ contract DirectBuyIssuerTest is Test {
         issuer.grantRole(issuer.ASSETTOKEN_ROLE(), address(token));
         issuer.grantRole(issuer.OPERATOR_ROLE(), operator);
 
-        dummyOrder = OrderProcessor.OrderRequest({
+        dummyOrder = IOrderBridge.OrderRequest({
             recipient: user,
             assetToken: address(token),
             paymentToken: address(paymentToken),
@@ -84,7 +84,7 @@ contract DirectBuyIssuerTest is Test {
     function testTakeEscrow(uint256 orderAmount, uint256 takeAmount) public {
         vm.assume(orderAmount > 0);
 
-        OrderProcessor.OrderRequest memory order = dummyOrder;
+        IOrderBridge.OrderRequest memory order = dummyOrder;
         order.quantityIn = orderAmount;
         (uint256 flatFee, uint256 percentageFee) = issuer.getFeesForOrder(order.paymentToken, order.quantityIn);
         uint256 fees = flatFee + percentageFee;
@@ -119,7 +119,7 @@ contract DirectBuyIssuerTest is Test {
     function testReturnEscrow(uint256 orderAmount, uint256 returnAmount) public {
         vm.assume(orderAmount > 0);
 
-        OrderProcessor.OrderRequest memory order = dummyOrder;
+        IOrderBridge.OrderRequest memory order = dummyOrder;
         order.quantityIn = orderAmount;
         (uint256 flatFee, uint256 percentageFee) = issuer.getFeesForOrder(order.paymentToken, order.quantityIn);
         uint256 fees = flatFee + percentageFee;
@@ -164,7 +164,7 @@ contract DirectBuyIssuerTest is Test {
     {
         vm.assume(takeAmount > 0);
 
-        OrderProcessor.OrderRequest memory order = dummyOrder;
+        IOrderBridge.OrderRequest memory order = dummyOrder;
         order.quantityIn = orderAmount;
         (uint256 flatFee, uint256 percentageFee) = issuer.getFeesForOrder(order.paymentToken, order.quantityIn);
         uint256 fees = flatFee + percentageFee;
@@ -209,7 +209,7 @@ contract DirectBuyIssuerTest is Test {
     function testCancelOrder(uint256 orderAmount, uint256 fillAmount, string calldata reason) public {
         vm.assume(orderAmount > 0);
 
-        OrderProcessor.OrderRequest memory order = dummyOrder;
+        IOrderBridge.OrderRequest memory order = dummyOrder;
         order.quantityIn = orderAmount;
         (uint256 flatFee, uint256 percentageFee) = issuer.getFeesForOrder(order.assetToken, order.quantityIn);
         uint256 fees = flatFee + percentageFee;
@@ -242,7 +242,7 @@ contract DirectBuyIssuerTest is Test {
         vm.assume(orderAmount > 0);
         vm.assume(takeAmount > 0);
 
-        OrderProcessor.OrderRequest memory order = dummyOrder;
+        IOrderBridge.OrderRequest memory order = dummyOrder;
         order.quantityIn = orderAmount;
         (uint256 flatFee, uint256 percentageFee) = issuer.getFeesForOrder(order.assetToken, order.quantityIn);
         uint256 fees = flatFee + percentageFee;

--- a/test/LimitBuyIssuer.t.sol
+++ b/test/LimitBuyIssuer.t.sol
@@ -26,7 +26,7 @@ contract LimitBuyIssuerTest is Test {
     address constant treasury = address(4);
 
     bytes32 constant salt = 0x0000000000000000000000000000000000000000000000000000000000000001;
-    OrderProcessor.OrderRequest dummyOrder;
+    IOrderBridge.OrderRequest dummyOrder;
     uint256 dummyOrderFees;
     IOrderBridge.Order dummyOrderBridgeData;
 
@@ -55,7 +55,7 @@ contract LimitBuyIssuerTest is Test {
     }
 
     function testRequestOrderLimit(uint256 quantityIn, uint256 _price) public {
-        dummyOrder = OrderProcessor.OrderRequest({
+        dummyOrder = IOrderBridge.OrderRequest({
             recipient: user,
             assetToken: address(token),
             paymentToken: address(paymentToken),
@@ -127,7 +127,7 @@ contract LimitBuyIssuerTest is Test {
         vm.assume(receivedAmount < 2 ** 128 - 1);
         vm.assume(orderAmount > 0);
 
-        OrderProcessor.OrderRequest memory order = OrderProcessor.OrderRequest({
+        OrderProcessor.OrderRequest memory order = IOrderBridge.OrderRequest({
             recipient: user,
             assetToken: address(token),
             paymentToken: address(paymentToken),

--- a/test/LimitSellProcessor.t.sol
+++ b/test/LimitSellProcessor.t.sol
@@ -26,7 +26,7 @@ contract LimitSellProcessorTest is Test {
     address constant treasury = address(4);
 
     bytes32 constant salt = 0x0000000000000000000000000000000000000000000000000000000000000001;
-    OrderProcessor.OrderRequest dummyOrder;
+    IOrderBridge.OrderRequest dummyOrder;
     uint256 dummyOrderFees;
     IOrderBridge.Order dummyOrderBridgeData;
 
@@ -55,7 +55,7 @@ contract LimitSellProcessorTest is Test {
     }
 
     function testRequestOrderLimit(uint256 quantityIn, uint256 _price) public {
-        OrderProcessor.OrderRequest memory order = OrderProcessor.OrderRequest({
+        IOrderBridge.OrderRequest memory order = IOrderBridge.OrderRequest({
             recipient: user,
             assetToken: address(token),
             paymentToken: address(paymentToken),
@@ -119,7 +119,7 @@ contract LimitSellProcessorTest is Test {
         vm.assume(fillAmount < 2 ** 128 - 1);
         vm.assume(receivedAmount < 2 ** 128 - 1);
 
-        OrderProcessor.OrderRequest memory order = OrderProcessor.OrderRequest({
+        IOrderBridge.OrderRequest memory order = IOrderBridge.OrderRequest({
             recipient: user,
             assetToken: address(token),
             paymentToken: address(paymentToken),

--- a/test/SellOrderProcessor.t.sol
+++ b/test/SellOrderProcessor.t.sol
@@ -30,7 +30,7 @@ contract SellOrderProcessorTest is Test {
     address constant treasury = address(4);
 
     bytes32 salt = 0x0000000000000000000000000000000000000000000000000000000000000001;
-    OrderProcessor.OrderRequest dummyOrder;
+    IOrderBridge.OrderRequest dummyOrder;
     IOrderBridge.Order dummyOrderBridgeData;
 
     function setUp() public {
@@ -56,7 +56,7 @@ contract SellOrderProcessorTest is Test {
         issuer.grantRole(issuer.ASSETTOKEN_ROLE(), address(token));
         issuer.grantRole(issuer.OPERATOR_ROLE(), operator);
 
-        dummyOrder = OrderProcessor.OrderRequest({
+        dummyOrder = IOrderBridge.OrderRequest({
             recipient: user,
             assetToken: address(token),
             paymentToken: address(paymentToken),
@@ -87,7 +87,7 @@ contract SellOrderProcessorTest is Test {
     }
 
     function testRequestOrder(uint256 quantityIn) public {
-        OrderProcessor.OrderRequest memory order = OrderProcessor.OrderRequest({
+        IOrderBridge.OrderRequest memory order = IOrderBridge.OrderRequest({
             recipient: user,
             assetToken: address(token),
             paymentToken: address(paymentToken),
@@ -139,7 +139,7 @@ contract SellOrderProcessorTest is Test {
     function testFillOrder(uint256 orderAmount, uint256 fillAmount, uint256 receivedAmount) public {
         vm.assume(orderAmount > 0);
 
-        OrderProcessor.OrderRequest memory order = dummyOrder;
+        IOrderBridge.OrderRequest memory order = dummyOrder;
         order.quantityIn = orderAmount;
 
         bytes32 orderId = issuer.getOrderIdFromOrderRequest(order, salt);
@@ -189,7 +189,7 @@ contract SellOrderProcessorTest is Test {
     function testFulfillOrder(uint256 orderAmount, uint256 receivedAmount) public {
         vm.assume(orderAmount > 0);
 
-        OrderProcessor.OrderRequest memory order = dummyOrder;
+        IOrderBridge.OrderRequest memory order = dummyOrder;
         order.quantityIn = orderAmount;
 
         bytes32 orderId = issuer.getOrderIdFromOrderRequest(order, salt);
@@ -236,7 +236,7 @@ contract SellOrderProcessorTest is Test {
         vm.assume(orderAmount > 0);
         vm.assume(fillAmount < orderAmount);
 
-        OrderProcessor.OrderRequest memory order = dummyOrder;
+        IOrderBridge.OrderRequest memory order = dummyOrder;
         order.quantityIn = orderAmount;
 
         token.mint(user, orderAmount);

--- a/test/gas/BuyOrderIssuerRequest.t.sol
+++ b/test/gas/BuyOrderIssuerRequest.t.sol
@@ -30,7 +30,7 @@ contract BuyOrderIssuerRequestTest is Test {
     bytes32 r;
     bytes32 s;
 
-    OrderProcessor.OrderRequest order;
+    IOrderBridge.OrderRequest order;
     bytes[] calls;
 
     function setUp() public {
@@ -71,7 +71,7 @@ contract BuyOrderIssuerRequestTest is Test {
 
         (v, r, s) = vm.sign(userPrivateKey, digest);
 
-        order = OrderProcessor.OrderRequest({
+        order = IOrderBridge.OrderRequest({
             recipient: user,
             assetToken: address(token),
             paymentToken: address(paymentToken),
@@ -112,7 +112,7 @@ contract BuyOrderIssuerRequestTest is Test {
 
         (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(userPrivateKey, digest);
 
-        OrderProcessor.OrderRequest memory neworder = OrderProcessor.OrderRequest({
+        IOrderBridge.OrderRequest memory neworder = IOrderBridge.OrderRequest({
             recipient: user,
             assetToken: address(token),
             paymentToken: address(paymentToken),


### PR DESCRIPTION
This will help make peripheral contracts more lightweight