### PR TITLE
feat: maxOrderDecimals default 0

### DIFF
--- a/src/orders/IOrderProcessor.sol
+++ b/src/orders/IOrderProcessor.sol
@@ -107,7 +107,7 @@ interface IOrderProcessor {
     /// @notice This function retrieves the number of decimal places configured for a given token
     /// @param token The address of the token for which the number of decimal places is fetched
     /// @return Returns the number of decimal places set for the specified token
-    function maxOrderDecimals(address token) external view returns (uint256);
+    function maxOrderDecimals(address token) external view returns (int8);
 
     /// @notice Get fee rates for an order
     /// @param requester Requester of order

--- a/test/main/FulfillmentRouter.t.sol
+++ b/test/main/FulfillmentRouter.t.sol
@@ -88,7 +88,7 @@ contract FulfillmentRouterTest is Test {
         issuer.grantRole(issuer.ASSETTOKEN_ROLE(), address(token));
         issuer.grantRole(issuer.OPERATOR_ROLE(), address(router));
         issuer.grantRole(issuer.OPERATOR_ROLE(), operator);
-        issuer.setMaxOrderDecimals(address(token), token.decimals());
+        issuer.setMaxOrderDecimals(address(token), int8(token.decimals()));
 
         vault.grantRole(vault.AUTHORIZED_OPERATOR_ROLE(), address(router));
 

--- a/test/main/FulfillmentRouter.t.sol
+++ b/test/main/FulfillmentRouter.t.sol
@@ -88,6 +88,7 @@ contract FulfillmentRouterTest is Test {
         issuer.grantRole(issuer.ASSETTOKEN_ROLE(), address(token));
         issuer.grantRole(issuer.OPERATOR_ROLE(), address(router));
         issuer.grantRole(issuer.OPERATOR_ROLE(), operator);
+        issuer.setMaxOrderDecimals(address(token), token.decimals());
 
         vault.grantRole(vault.AUTHORIZED_OPERATOR_ROLE(), address(router));
 

--- a/test/main/LimitOrders.t.sol
+++ b/test/main/LimitOrders.t.sol
@@ -80,6 +80,7 @@ contract LimitOrderTest is Test {
         issuer.grantRole(issuer.PAYMENTTOKEN_ROLE(), address(paymentToken));
         issuer.grantRole(issuer.ASSETTOKEN_ROLE(), address(token));
         issuer.grantRole(issuer.OPERATOR_ROLE(), operator);
+        issuer.setMaxOrderDecimals(address(token), token.decimals());
 
         vm.stopPrank();
     }

--- a/test/main/LimitOrders.t.sol
+++ b/test/main/LimitOrders.t.sol
@@ -80,7 +80,7 @@ contract LimitOrderTest is Test {
         issuer.grantRole(issuer.PAYMENTTOKEN_ROLE(), address(paymentToken));
         issuer.grantRole(issuer.ASSETTOKEN_ROLE(), address(token));
         issuer.grantRole(issuer.OPERATOR_ROLE(), operator);
-        issuer.setMaxOrderDecimals(address(token), token.decimals());
+        issuer.setMaxOrderDecimals(address(token), int8(token.decimals()));
 
         vm.stopPrank();
     }

--- a/test/main/OrderProcessor.t.sol
+++ b/test/main/OrderProcessor.t.sol
@@ -20,7 +20,7 @@ contract OrderProcessorTest is Test {
     event FeesSet(address indexed account, OrderProcessor.FeeRates feeRates);
     event OrdersPaused(bool paused);
     event TokenLockCheckSet(ITokenLockCheck indexed tokenLockCheck);
-    event MaxOrderDecimalsSet(address indexed assetToken, uint256 decimals);
+    event MaxOrderDecimalsSet(address indexed assetToken, int8 decimals);
 
     event OrderRequested(uint256 indexed id, address indexed recipient, IOrderProcessor.Order order);
     event OrderFill(
@@ -94,7 +94,7 @@ contract OrderProcessorTest is Test {
         issuer.grantRole(issuer.PAYMENTTOKEN_ROLE(), address(paymentToken));
         issuer.grantRole(issuer.ASSETTOKEN_ROLE(), address(token));
         issuer.grantRole(issuer.OPERATOR_ROLE(), operator);
-        issuer.setMaxOrderDecimals(address(token), token.decimals());
+        issuer.setMaxOrderDecimals(address(token), int8(token.decimals()));
 
         dummyOrderFees = issuer.estimateTotalFeesForOrder(user, false, address(paymentToken), 100 ether);
 

--- a/test/main/OrderProcessor.t.sol
+++ b/test/main/OrderProcessor.t.sol
@@ -94,6 +94,7 @@ contract OrderProcessorTest is Test {
         issuer.grantRole(issuer.PAYMENTTOKEN_ROLE(), address(paymentToken));
         issuer.grantRole(issuer.ASSETTOKEN_ROLE(), address(token));
         issuer.grantRole(issuer.OPERATOR_ROLE(), operator);
+        issuer.setMaxOrderDecimals(address(token), token.decimals());
 
         dummyOrderFees = issuer.estimateTotalFeesForOrder(user, false, address(paymentToken), 100 ether);
 
@@ -358,9 +359,9 @@ contract OrderProcessorTest is Test {
         OrderProcessor.Order memory order = getDummyOrder(true);
 
         vm.expectEmit(true, true, true, true);
-        emit MaxOrderDecimalsSet(order.assetToken, 2);
+        emit MaxOrderDecimalsSet(order.assetToken, 0);
         vm.prank(admin);
-        issuer.setMaxOrderDecimals(order.assetToken, 2);
+        issuer.setMaxOrderDecimals(order.assetToken, 0);
         order.assetTokenQuantity = orderAmount;
 
         vm.prank(admin);
@@ -373,9 +374,11 @@ contract OrderProcessorTest is Test {
         issuer.requestOrder(order);
 
         // update OrderAmount
-        order.assetTokenQuantity = 100000;
+        order.assetTokenQuantity = 10 ** token.decimals();
 
         vm.prank(admin);
+        token.mint(user, order.assetTokenQuantity);
+        vm.prank(user);
         token.approve(address(issuer), order.assetTokenQuantity);
 
         vm.prank(user);


### PR DESCRIPTION
Improved `maxOrderDecimals` check. Default is no support for fractional shares.

For limit orders and market sells, requires the user place an order without precision specified beyond `maxOrderDecimals` for that token.