### PR TITLE
feat: store perOrderFee with 8 decimals, increasing range

### DIFF
--- a/script/AddPaymentTokens.s.sol
+++ b/script/AddPaymentTokens.s.sol
@@ -21,9 +21,9 @@ contract AddPaymentTokens is Script {
         vm.startBroadcast(deployerPrivateKey);
 
         OrderProcessor.FeeRates memory defaultFees = OrderProcessor.FeeRates({
-            perOrderFeeBuy: 1 ether,
+            perOrderFeeBuy: 1e8,
             percentageFeeRateBuy: 0,
-            perOrderFeeSell: 1 ether,
+            perOrderFeeSell: 1e8,
             percentageFeeRateSell: 5_000
         });
         for (uint256 i = 0; i < paymentTokens.length; i++) {

--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -113,9 +113,9 @@ contract DeployAll is Script {
 
         // // config payment token
         // OrderProcessor.FeeRates memory defaultFees = OrderProcessor.FeeRates({
-        //     perOrderFeeBuy: 1 ether,
+        //     perOrderFeeBuy: 1e8,
         //     percentageFeeRateBuy: 0,
-        //     perOrderFeeSell: 1 ether,
+        //     perOrderFeeSell: 1e8,
         //     percentageFeeRateSell: 5_000
         // });
 

--- a/script/SetFees.s.sol
+++ b/script/SetFees.s.sol
@@ -17,9 +17,9 @@ contract SetFees is Script {
         address usdt = vm.envAddress("USDT");
 
         OrderProcessor.FeeRates memory fees = OrderProcessor.FeeRates({
-            // perOrderFeeBuy: 1 ether,
+            // perOrderFeeBuy: 1e8,
             // percentageFeeRateBuy: 5_000,
-            // perOrderFeeSell: 1 ether,
+            // perOrderFeeSell: 1e8,
             // percentageFeeRateSell: 5_000
             perOrderFeeBuy: 0,
             percentageFeeRateBuy: 0,

--- a/src/common/FeeLib.sol
+++ b/src/common/FeeLib.sol
@@ -8,6 +8,8 @@ library FeeLib {
     // 1_000_000 == 100%
     uint24 private constant _ONEHUNDRED_PERCENT = 1_000_000;
 
+    uint64 private constant _FLAT_FEE_DECIMALS = 8;
+
     /// @dev Fee is too large
     error FeeTooLarge();
     /// @dev Decimals are too large
@@ -25,9 +27,13 @@ library FeeLib {
     function flatFeeForOrder(address token, uint64 perOrderFee) internal view returns (uint256 flatFee) {
         uint8 decimals = IERC20Metadata(token).decimals();
         if (decimals > 18) revert DecimalsTooLarge();
-        flatFee = perOrderFee;
-        if (flatFee != 0 && decimals < 18) {
-            flatFee /= 10 ** (18 - decimals);
+        if (perOrderFee == 0) return 0;
+        if (decimals > _FLAT_FEE_DECIMALS) {
+            flatFee = perOrderFee * 10 ** (decimals - _FLAT_FEE_DECIMALS);
+        } else if (decimals < _FLAT_FEE_DECIMALS) {
+            flatFee = perOrderFee / 10 ** (_FLAT_FEE_DECIMALS - decimals);
+        } else {
+            flatFee = perOrderFee;
         }
     }
 

--- a/src/orders/OrderProcessor.sol
+++ b/src/orders/OrderProcessor.sol
@@ -79,9 +79,13 @@ contract OrderProcessor is
     }
 
     struct FeeRates {
+        // 8 decimals
         uint64 perOrderFeeBuy;
+        // hundreths of a bip
         uint24 percentageFeeRateBuy;
+        // 8 decimals
         uint64 perOrderFeeSell;
+        // hundreths of a bip
         uint24 percentageFeeRateSell;
     }
 

--- a/test/forwarder/ForwarderLink.t.sol
+++ b/test/forwarder/ForwarderLink.t.sol
@@ -124,9 +124,9 @@ contract ForwarderLinkTest is Test {
         token.grantRole(token.BURNER_ROLE(), address(issuer));
 
         OrderProcessor.FeeRates memory defaultFees = OrderProcessor.FeeRates({
-            perOrderFeeBuy: 1 ether,
+            perOrderFeeBuy: 1e8,
             percentageFeeRateBuy: 5_000,
-            perOrderFeeSell: 1 ether,
+            perOrderFeeSell: 1e8,
             percentageFeeRateSell: 5_000
         });
         issuer.setDefaultFees(address(paymentToken), defaultFees);

--- a/test/forwarder/ForwarderPyth.t.sol
+++ b/test/forwarder/ForwarderPyth.t.sol
@@ -128,9 +128,9 @@ contract ForwarderPythTest is Test {
         token.grantRole(token.BURNER_ROLE(), address(issuer));
 
         OrderProcessor.FeeRates memory defaultFees = OrderProcessor.FeeRates({
-            perOrderFeeBuy: 1 ether,
+            perOrderFeeBuy: 1e8,
             percentageFeeRateBuy: 5_000,
-            perOrderFeeSell: 1 ether,
+            perOrderFeeSell: 1e8,
             percentageFeeRateSell: 5_000
         });
         issuer.setDefaultFees(address(paymentToken), defaultFees);

--- a/test/forwarder/dShareCompat.t.sol
+++ b/test/forwarder/dShareCompat.t.sol
@@ -86,9 +86,9 @@ contract dShareCompatTest is Test {
 
         vm.startPrank(admin);
         OrderProcessor.FeeRates memory defaultFees = OrderProcessor.FeeRates({
-            perOrderFeeBuy: 1 ether,
+            perOrderFeeBuy: 1e8,
             percentageFeeRateBuy: 5_000,
-            perOrderFeeSell: 1 ether,
+            perOrderFeeSell: 1e8,
             percentageFeeRateSell: 5_000
         });
         issuer.setDefaultFees(address(paymentToken), defaultFees);

--- a/test/forwarder/gas/ForwarderRequestCancel.t.sol
+++ b/test/forwarder/gas/ForwarderRequestCancel.t.sol
@@ -92,9 +92,9 @@ contract ForwarderRequestCancelTest is Test {
         token.grantRole(token.BURNER_ROLE(), address(issuer));
 
         OrderProcessor.FeeRates memory defaultFees = OrderProcessor.FeeRates({
-            perOrderFeeBuy: 1 ether,
+            perOrderFeeBuy: 1e8,
             percentageFeeRateBuy: 5_000,
-            perOrderFeeSell: 1 ether,
+            perOrderFeeSell: 1e8,
             percentageFeeRateSell: 5_000
         });
         issuer.setDefaultFees(address(paymentToken), defaultFees);

--- a/test/main/BuyUnlockedProcessor.t.sol
+++ b/test/main/BuyUnlockedProcessor.t.sol
@@ -77,9 +77,9 @@ contract BuyUnlockedProcessorTest is Test {
         token.grantRole(token.MINTER_ROLE(), address(issuer));
 
         OrderProcessor.FeeRates memory defaultFees = OrderProcessor.FeeRates({
-            perOrderFeeBuy: 1 ether,
+            perOrderFeeBuy: 1e8,
             percentageFeeRateBuy: 5_000,
-            perOrderFeeSell: 1 ether,
+            perOrderFeeSell: 1e8,
             percentageFeeRateSell: 5_000
         });
         issuer.setDefaultFees(address(paymentToken), defaultFees);

--- a/test/main/FeeLib.t.sol
+++ b/test/main/FeeLib.t.sol
@@ -14,7 +14,7 @@ contract FeeLibTest is Test {
 
     function testUSDCFlatFee() public {
         // 1 USDC flat fee
-        uint256 flatFee = wrapFlatFeeForOrder(address(usdc), 1 ether);
+        uint256 flatFee = wrapFlatFeeForOrder(address(usdc), 1e8);
         assertEq(flatFee, 1e6);
     }
 

--- a/test/main/FulfillmentRouter.t.sol
+++ b/test/main/FulfillmentRouter.t.sol
@@ -78,9 +78,9 @@ contract FulfillmentRouterTest is Test {
         token.grantRole(token.BURNER_ROLE(), address(issuer));
 
         OrderProcessor.FeeRates memory defaultFees = OrderProcessor.FeeRates({
-            perOrderFeeBuy: 1 ether,
+            perOrderFeeBuy: 1e8,
             percentageFeeRateBuy: 5_000,
-            perOrderFeeSell: 1 ether,
+            perOrderFeeSell: 1e8,
             percentageFeeRateSell: 5_000
         });
         issuer.setDefaultFees(address(paymentToken), defaultFees);

--- a/test/main/LimitOrders.t.sol
+++ b/test/main/LimitOrders.t.sol
@@ -70,9 +70,9 @@ contract LimitOrderTest is Test {
         token.grantRole(token.BURNER_ROLE(), address(issuer));
 
         OrderProcessor.FeeRates memory defaultFees = OrderProcessor.FeeRates({
-            perOrderFeeBuy: 1 ether,
+            perOrderFeeBuy: 1e8,
             percentageFeeRateBuy: 5_000,
-            perOrderFeeSell: 1 ether,
+            perOrderFeeSell: 1e8,
             percentageFeeRateSell: 5_000
         });
         issuer.setDefaultFees(address(paymentToken), defaultFees);

--- a/test/main/OrderProcessor.t.sol
+++ b/test/main/OrderProcessor.t.sol
@@ -85,9 +85,9 @@ contract OrderProcessorTest is Test {
         token.grantRole(token.BURNER_ROLE(), address(issuer));
 
         OrderProcessor.FeeRates memory defaultFees = OrderProcessor.FeeRates({
-            perOrderFeeBuy: 1 ether,
+            perOrderFeeBuy: 1e8,
             percentageFeeRateBuy: 5_000,
-            perOrderFeeSell: 1 ether,
+            perOrderFeeSell: 1e8,
             percentageFeeRateSell: 5_000
         });
         issuer.setDefaultFees(address(paymentToken), defaultFees);
@@ -198,7 +198,8 @@ contract OrderProcessorTest is Test {
                 this.wrapFlatFeeForOrder(address(newToken), perOrderFee);
             } else {
                 assertEq(
-                    wrapFlatFeeForOrder(address(newToken), perOrderFee), decimalAdjust(newToken.decimals(), perOrderFee)
+                    wrapFlatFeeForOrder(address(newToken), perOrderFee),
+                    decimalAdjust(8, newToken.decimals(), perOrderFee)
                 );
             }
         }
@@ -778,12 +779,12 @@ contract OrderProcessorTest is Test {
         return FeeLib.flatFeeForOrder(newToken, perOrderFee);
     }
 
-    function decimalAdjust(uint8 decimals, uint256 fee) internal pure returns (uint256) {
+    function decimalAdjust(uint8 startDecimals, uint8 decimals, uint256 fee) internal pure returns (uint256) {
         uint256 adjFee = fee;
-        if (decimals < 18) {
-            adjFee /= 10 ** (18 - decimals);
-        } else if (decimals > 18) {
-            adjFee *= 10 ** (decimals - 18);
+        if (decimals < startDecimals) {
+            adjFee /= 10 ** (startDecimals - decimals);
+        } else if (decimals > startDecimals) {
+            adjFee *= 10 ** (decimals - startDecimals);
         }
         return adjFee;
     }

--- a/test/main/gas/BuyOrderIssuerRequest.t.sol
+++ b/test/main/gas/BuyOrderIssuerRequest.t.sol
@@ -71,9 +71,9 @@ contract BuyProcessorRequestTest is Test {
         token.grantRole(token.MINTER_ROLE(), address(issuer));
 
         OrderProcessor.FeeRates memory defaultFees = OrderProcessor.FeeRates({
-            perOrderFeeBuy: 1 ether,
+            perOrderFeeBuy: 1e8,
             percentageFeeRateBuy: 5_000,
-            perOrderFeeSell: 1 ether,
+            perOrderFeeSell: 1e8,
             percentageFeeRateSell: 5_000
         });
         issuer.setDefaultFees(address(paymentToken), defaultFees);


### PR DESCRIPTION
Current use of perOrderFee limits max fee to ~18.

Default and per account fees will need to be updated on deployed contracts accordingly.