### PR TITLE
chore: validated encode call script

### DIFF
--- a/script/EncodeInit.s.sol
+++ b/script/EncodeInit.s.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.22;
+
+import "forge-std/Script.sol";
+import "../src/DShareFactory.sol";
+
+contract Encode is Script {
+    function run() external {
+        bytes memory data = abi.encodeCall(DShareFactory.initializeV2, ());
+        console.log("Encoded call:");
+        console.logBytes(data);
+    }
+}


### PR DESCRIPTION
`initializeV2()` => `0x5cd8a76b`