### PR TITLE
[Dshare 211] onchain order fill data

### DIFF
--- a/.gas-report
+++ b/.gas-report
@@ -18,62 +18,63 @@
 | beginDefaultAdminTransfer                                                                 | 54990           | 54990  | 54990  | 54990  | 1       |
 | burn                                                                                      | 28760           | 36430  | 36237  | 52990  | 514     |
 | burnFrom                                                                                  | 46490           | 46973  | 46797  | 49952  | 256     |
-| cancelOrder                                                                               | 35489           | 104179 | 89660  | 121415 | 513     |
+| cancelOrder                                                                               | 35489           | 104182 | 89660  | 121415 | 513     |
 | convertToAssets                                                                           | 2851            | 2851   | 2851   | 2851   | 147     |
 | createDShare                                                                              | 32578           | 462743 | 700365 | 966734 | 562     |
-| createOrderStandardFees                                                                   | 30677           | 148530 | 165057 | 237884 | 6150    |
-| createOrderWithSignature                                                                  | 177597          | 200533 | 200654 | 223419 | 512     |
-| dShareFactory                                                                             | 2814            | 2814   | 2814   | 2814   | 1       |
+| createOrderStandardFees                                                                   | 30699           | 148552 | 165067 | 237906 | 6150    |
+| createOrderWithSignature                                                                  | 177619          | 200557 | 200676 | 223441 | 512     |
+| dShareFactory                                                                             | 2769            | 2769   | 2769   | 2769   | 1       |
 | decimals                                                                                  | 726             | 726    | 726    | 726    | 1       |
 | deposit                                                                                   | 73317           | 128873 | 129113 | 131437 | 1026    |
-| fillOrder                                                                                 | 31923           | 130534 | 124929 | 231214 | 2803    |
+| fillOrder                                                                                 | 31923           | 152582 | 169101 | 275614 | 2803    |
 | getDShareBeacon                                                                           | 3264            | 3264   | 3264   | 3264   | 1       |
 | getDShares                                                                                | 3962            | 7712   | 7712   | 11462  | 512     |
-| getFeesEscrowed                                                                           | 928             | 928    | 928    | 928    | 256     |
-| getFeesTaken                                                                              | 884             | 884    | 884    | 884    | 93      |
-| getOrderStatus                                                                            | 983             | 984    | 983    | 3483   | 2466    |
+| getFeesEscrowed                                                                           | 884             | 884    | 884    | 884    | 256     |
+| getFeesTaken                                                                              | 884             | 884    | 884    | 884    | 99      |
+| getOrderStatus                                                                            | 983             | 984    | 983    | 3483   | 2474    |
+| getOrderTrackedAmount                                                                     | 1113            | 3528   | 5113   | 5113   | 424     |
 | getPaymentTokenConfig                                                                     | 6277            | 6277   | 6277   | 6277   | 256     |
 | getStandardFees                                                                           | 2192            | 6361   | 8692   | 8692   | 2348    |
 | getTransferRestrictor                                                                     | 704             | 704    | 704    | 704    | 1       |
-| getUnfilledAmount                                                                         | 885             | 1638   | 885    | 7385   | 2209    |
+| getUnfilledAmount                                                                         | 907             | 1604   | 907    | 7407   | 2385    |
 | getWrappedDShareBeacon                                                                    | 714             | 714    | 714    | 714    | 1       |
 | grantRole                                                                                 | 56134           | 56347  | 56374  | 56374  | 2574    |
 | hasRole                                                                                   | 3605            | 5605   | 5605   | 7605   | 2       |
-| hashFeeQuote                                                                              | 1608            | 1608   | 1608   | 1608   | 512     |
-| hashOrder                                                                                 | 2622            | 3374   | 2622   | 7122   | 1537    |
+| hashFeeQuote                                                                              | 1630            | 1630   | 1630   | 1630   | 512     |
+| hashOrder                                                                                 | 2644            | 3396   | 2644   | 7144   | 1537    |
 | hashOrderRequest                                                                          | 2966            | 2966   | 2966   | 2966   | 512     |
 | initializeV2                                                                              | 28438           | 43077  | 43077  | 57716  | 2       |
 | isBlacklisted                                                                             | 1946            | 3536   | 3325   | 7204   | 1536    |
 | isOperator                                                                                | 5505            | 5505   | 5505   | 5505   | 256     |
 | isTokenDShare                                                                             | 5543            | 7373   | 7543   | 7543   | 6032    |
 | isTokenWrappedDShare                                                                      | 1042            | 1042   | 1042   | 1042   | 512     |
-| isTransferLocked                                                                          | 2768            | 6018   | 6018   | 9268   | 512     |
-| latestFillPrice                                                                           | 1629            | 1629   | 1629   | 1629   | 349     |
+| isTransferLocked                                                                          | 2726            | 5976   | 5976   | 9226   | 512     |
+| latestFillPrice                                                                           | 1651            | 1651   | 1651   | 1651   | 355     |
 | maxWithdraw                                                                               | 3120            | 3120   | 3120   | 3120   | 5       |
 | mint(address,uint256)                                                                     | 29032           | 82102  | 88181  | 89049  | 4104    |
 | mint(uint256,address)                                                                     | 75354           | 129296 | 129246 | 131462 | 512     |
-| multicall                                                                                 | 258421          | 284294 | 274208 | 320202 | 770     |
+| multicall                                                                                 | 258465          | 284342 | 274258 | 320258 | 770     |
 | name                                                                                      | 1358            | 2918   | 3861   | 8040   | 513     |
 | orderDecimalReduction                                                                     | 1028            | 1028   | 1028   | 1028   | 1       |
 | ordersPaused                                                                              | 5253            | 5253   | 5253   | 5253   | 256     |
-| owner                                                                                     | 806             | 4057   | 4057   | 7309   | 2       |
+| owner                                                                                     | 806             | 4068   | 4068   | 7331   | 2       |
 | pendingDefaultAdmin                                                                       | 3285            | 3285   | 3285   | 3285   | 1       |
 | redeem                                                                                    | 67735           | 84076  | 87887  | 95247  | 513     |
-| removePaymentToken                                                                        | 28743           | 30600  | 30557  | 32372  | 512     |
-| requestCancel                                                                             | 28642           | 28778  | 28690  | 30580  | 258     |
+| removePaymentToken                                                                        | 28765           | 30618  | 30579  | 32394  | 512     |
+| requestCancel                                                                             | 28642           | 28777  | 28690  | 30580  | 258     |
 | revokeRole                                                                                | 26915           | 26915  | 26915  | 26915  | 1       |
 | selfPermit                                                                                | 55432           | 58721  | 55432  | 83584  | 771     |
 | setBalancePerShare                                                                        | 28804           | 34197  | 34912  | 35068  | 2050    |
 | setName                                                                                   | 29089           | 50262  | 36474  | 104663 | 768     |
 | setNewTransferRestrictor                                                                  | 26499           | 28301  | 28301  | 30103  | 2       |
-| setOperator                                                                               | 28964           | 42227  | 52605  | 52833  | 817     |
+| setOperator                                                                               | 28964           | 42229  | 52605  | 52833  | 817     |
 | setOrderDecimalReduction                                                                  | 52865           | 52865  | 52865  | 52865  | 1       |
 | setOrdersPaused                                                                           | 28709           | 32325  | 34779  | 34779  | 768     |
-| setPaymentToken                                                                           | 30076           | 48396  | 62580  | 64270  | 1073    |
+| setPaymentToken                                                                           | 30076           | 48397  | 62580  | 64270  | 1073    |
 | setSymbol                                                                                 | 29079           | 50244  | 36454  | 104631 | 768     |
 | setTransferRestrictor                                                                     | 30159           | 31399  | 30159  | 35199  | 1024    |
-| setTreasury                                                                               | 28732           | 31958  | 28960  | 35124  | 513     |
-| setVault                                                                                  | 28755           | 31987  | 28983  | 35159  | 513     |
+| setTreasury                                                                               | 28732           | 31955  | 28960  | 35124  | 513     |
+| setVault                                                                                  | 28755           | 31984  | 28983  | 35159  | 513     |
 | sharesToBalance                                                                           | 1117            | 1129   | 1117   | 1197   | 768     |
 | symbol                                                                                    | 1379            | 2918   | 3561   | 4429   | 513     |
 | totalSupply                                                                               | 1147            | 1154   | 1147   | 1227   | 1283    |
@@ -91,13 +92,13 @@
 | BURNER_ROLE                                                                            | 1187            | 1187  | 1187   | 1187  | 46      |
 | DOMAIN_SEPARATOR                                                                       | 2203            | 2203  | 2203   | 2203  | 2       |
 | MINTER_ROLE                                                                            | 1208            | 1208  | 1208   | 1208  | 96      |
-| approve                                                                                | 36888           | 54086 | 54096  | 54300 | 1794    |
+| approve                                                                                | 36888           | 54082 | 54084  | 54300 | 1794    |
 | asset                                                                                  | 1349            | 6684  | 10349  | 10349 | 1537    |
-| balanceOf                                                                              | 1896            | 3397  | 1896   | 12896 | 3514    |
+| balanceOf                                                                              | 1896            | 3398  | 1896   | 12896 | 3526    |
 | decimals                                                                               | 8213            | 8213  | 8213   | 8213  | 1       |
 | grantRole                                                                              | 59415           | 59423 | 59427  | 59427 | 142     |
 | isBlacklisted                                                                          | 4499            | 15118 | 15999  | 15999 | 5381    |
-| mint                                                                                   | 57298           | 91676 | 91618  | 92102 | 1794    |
+| mint                                                                                   | 57298           | 91672 | 91618  | 92102 | 1794    |
 | name                                                                                   | 1914            | 3606  | 2318   | 10480 | 768     |
 | owner                                                                                  | 1316            | 1337  | 1337   | 1359  | 512     |
 | symbol                                                                                 | 1910            | 5932  | 2336   | 17476 | 768     |
@@ -107,15 +108,15 @@
 | Deployment Cost                                                                                    | Deployment Size |      |        |      |         |
 | 305890                                                                                             | 1389            |      |        |      |         |
 | Function Name                                                                                      | min             | avg  | median | max  | # calls |
-| implementation                                                                                     | 306             | 1424 | 2306   | 2306 | 22559   |
+| implementation                                                                                     | 306             | 1424 | 2306   | 2306 | 22577   |
 | lib/solady/test/utils/mocks/MockERC20.sol:MockERC20 contract |                 |       |        |       |         |
 |--------------------------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                                              | Deployment Size |       |        |       |         |
-| 765884                                                       | 3890            |       |        |       |         |
+| 765980                                                       | 3890            |       |        |       |         |
 | Function Name                                                | min             | avg   | median | max   | # calls |
 | approve                                                      | 26057           | 45844 | 45993  | 46341 | 1024    |
 | balanceOf                                                    | 596             | 899   | 596    | 2596  | 1688    |
-| decimals                                                     | 311             | 1689  | 2311   | 2311  | 373     |
+| decimals                                                     | 311             | 1681  | 2311   | 2311  | 375     |
 | mint                                                         | 28108           | 67619 | 68052  | 68520 | 1024    |
 | src/DShare.sol:DShare contract |                 |        |        |        |         |
 |--------------------------------|-----------------|--------|--------|--------|---------|
@@ -129,18 +130,18 @@
 | acceptDefaultAdminTransfer     | 2406            | 16110  | 2622   | 43302  | 3       |
 | allowance                      | 668             | 668    | 668    | 668    | 256     |
 | approve                        | 4525            | 24292  | 24425  | 24425  | 3588    |
-| balanceOf                      | 968             | 2313   | 968    | 4968   | 9451    |
+| balanceOf                      | 968             | 2314   | 968    | 4968   | 9463    |
 | balancePerShare                | 430             | 430    | 430    | 430    | 256     |
 | balanceToShares                | 765             | 811    | 765    | 1057   | 512     |
 | beginDefaultAdminTransfer      | 28914           | 28914  | 28914  | 28914  | 1       |
 | burn                           | 2686            | 14488  | 11970  | 27146  | 514     |
-| burnFrom                       | 22999           | 27713  | 25645  | 38237  | 2305    |
+| burnFrom                       | 22999           | 27714  | 25645  | 38237  | 2305    |
 | decimals                       | 288             | 288    | 288    | 288    | 1       |
 | grantRole                      | 29555           | 29555  | 29555  | 29555  | 2716    |
 | hasRole                        | 727             | 1727   | 1727   | 2727   | 2       |
 | initialize                     | 143757          | 203970 | 208067 | 274648 | 591     |
 | isBlacklisted                  | 596             | 6774   | 8071   | 8071   | 6405    |
-| mint                           | 2815            | 58435  | 61938  | 62230  | 7258    |
+| mint                           | 2815            | 58437  | 61938  | 62230  | 7264    |
 | name                           | 986             | 2661   | 1384   | 9543   | 768     |
 | owner                          | 434             | 434    | 434    | 434    | 257     |
 | pendingDefaultAdmin            | 410             | 410    | 410    | 410    | 1       |
@@ -180,7 +181,7 @@
 | RESTRICTOR_ROLE                                        | 284             | 284   | 284    | 284   | 322     |
 | grantRole                                              | 51215           | 51215 | 51215  | 51215 | 66      |
 | isBlacklisted                                          | 593             | 2208  | 2593   | 2593  | 6661    |
-| requireNotRestricted                                   | 675             | 4194  | 4829   | 4860  | 16225   |
+| requireNotRestricted                                   | 675             | 4194  | 4829   | 4860  | 16231   |
 | restrict                                               | 23922           | 43976 | 47205  | 47433 | 1792    |
 | unrestrict                                             | 25309           | 25468 | 25549  | 25549 | 256     |
 | src/WrappedDShare.sol:WrappedDShare contract |                 |        |        |        |         |
@@ -222,42 +223,43 @@
 | src/orders/FulfillmentRouter.sol:FulfillmentRouter contract |                 |        |        |        |         |
 |-------------------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                             | Deployment Size |        |        |        |         |
-| 1848558                                                     | 8623            |        |        |        |         |
+| 1848570                                                     | 8623            |        |        |        |         |
 | Function Name                                               | min             | avg    | median | max    | # calls |
 | OPERATOR_ROLE                                               | 282             | 282    | 282    | 282    | 6       |
-| cancelBuyOrder                                              | 28204           | 84602  | 79830  | 141079 | 512     |
-| fillOrder                                                   | 27373           | 217190 | 221168 | 232807 | 514     |
+| cancelBuyOrder                                              | 28204           | 84611  | 79839  | 141096 | 512     |
+| fillOrder                                                   | 27373           | 252644 | 256640 | 277207 | 514     |
 | grantRole                                                   | 51331           | 51331  | 51331  | 51331  | 5       |
 | src/orders/OrderProcessor.sol:OrderProcessor contract |                 |        |        |        |         |
 |-------------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                       | Deployment Size |        |        |        |         |
-| 5087117                                               | 23570           |        |        |        |         |
+| 5126831                                               | 23753           |        |        |        |         |
 | Function Name                                         | min             | avg    | median | max    | # calls |
 | DOMAIN_SEPARATOR                                      | 2433            | 4433   | 4433   | 6433   | 1024    |
-| cancelOrder                                           | 6880            | 83097  | 81640  | 101086 | 769     |
-| createOrderStandardFees                               | 2542            | 128877 | 151119 | 219050 | 6150    |
-| createOrderWithSignature                              | 177068          | 200004 | 200125 | 222890 | 512     |
-| dShareFactory                                         | 2442            | 2442   | 2442   | 2442   | 1       |
-| fillOrder                                             | 2738            | 118306 | 151740 | 201685 | 3315    |
-| getFeesEscrowed                                       | 553             | 553    | 553    | 553    | 256     |
-| getFeesTaken                                          | 509             | 509    | 509    | 509    | 93      |
-| getOrderStatus                                        | 608             | 608    | 608    | 608    | 2466    |
+| cancelOrder                                           | 6880            | 83098  | 81640  | 101086 | 769     |
+| createOrderStandardFees                               | 2564            | 128900 | 151141 | 219072 | 6150    |
+| createOrderWithSignature                              | 177090          | 200028 | 200147 | 222912 | 512     |
+| dShareFactory                                         | 2397            | 2397   | 2397   | 2397   | 1       |
+| fillOrder                                             | 2738            | 143979 | 195411 | 246085 | 3315    |
+| getFeesEscrowed                                       | 509             | 509    | 509    | 509    | 256     |
+| getFeesTaken                                          | 509             | 509    | 509    | 509    | 99      |
+| getOrderStatus                                        | 608             | 608    | 608    | 608    | 2474    |
+| getOrderTrackedAmount                                 | 735             | 3150   | 4735   | 4735   | 424     |
 | getPaymentTokenConfig                                 | 1372            | 1372   | 1372   | 1372   | 256     |
 | getStandardFees                                       | 1045            | 3036   | 3811   | 3811   | 2348    |
-| getUnfilledAmount                                     | 510             | 741    | 510    | 2510   | 2209    |
-| hashFeeQuote                                          | 1212            | 1212   | 1212   | 1212   | 512     |
-| hashOrder                                             | 2196            | 2196   | 2196   | 2196   | 1537    |
+| getUnfilledAmount                                     | 532             | 746    | 532    | 2532   | 2385    |
+| hashFeeQuote                                          | 1234            | 1234   | 1234   | 1234   | 512     |
+| hashOrder                                             | 2218            | 2218   | 2218   | 2218   | 1537    |
 | hashOrderRequest                                      | 2534            | 2534   | 2534   | 2534   | 512     |
 | initialize                                            | 99773           | 163629 | 167537 | 167537 | 52      |
 | isOperator                                            | 630             | 630    | 630    | 630    | 256     |
-| isTransferLocked                                      | 2390            | 3390   | 3390   | 4390   | 512     |
-| latestFillPrice                                       | 1248            | 1248   | 1248   | 1248   | 349     |
-| multicall                                             | 246766          | 263849 | 261947 | 282791 | 770     |
+| isTransferLocked                                      | 2348            | 3348   | 3348   | 4348   | 512     |
+| latestFillPrice                                       | 1270            | 1270   | 1270   | 1270   | 355     |
+| multicall                                             | 246810          | 263894 | 261991 | 282835 | 770     |
 | orderDecimalReduction                                 | 653             | 653    | 653    | 653    | 1       |
 | ordersPaused                                          | 381             | 381    | 381    | 381    | 256     |
-| owner                                                 | 2437            | 2437   | 2437   | 2437   | 1       |
+| owner                                                 | 2459            | 2459   | 2459   | 2459   | 1       |
 | proxiableUUID                                         | 343             | 343    | 343    | 343    | 1       |
-| removePaymentToken                                    | 2672            | 4370   | 4370   | 6068   | 512     |
+| removePaymentToken                                    | 2694            | 4392   | 4392   | 6090   | 512     |
 | requestCancel                                         | 2574            | 2580   | 2574   | 4132   | 258     |
 | selfPermit                                            | 55027           | 58279  | 55027  | 64824  | 771     |
 | setOperator                                           | 2762            | 15914  | 26386  | 26386  | 817     |
@@ -277,20 +279,20 @@
 | DEFAULT_ADMIN_ROLE                  | 260             | 260   | 260    | 260   | 256     |
 | OPERATOR_ROLE                       | 282             | 282   | 282    | 282   | 517     |
 | grantRole                           | 51214           | 51218 | 51214  | 51442 | 261     |
-| rescueERC20                         | 24573           | 38897 | 30108  | 53543 | 512     |
-| withdrawFunds                       | 24577           | 39802 | 31121  | 55362 | 512     |
+| rescueERC20                         | 24573           | 38898 | 30108  | 53543 | 512     |
+| withdrawFunds                       | 24565           | 39807 | 31121  | 55362 | 512     |
 | test/OrderProcessor.t.sol:OrderProcessorTest contract |                 |     |        |     |         |
 |-------------------------------------------------------|-----------------|-----|--------|-----|---------|
 | Deployment Cost                                       | Deployment Size |     |        |     |         |
-| 26834919                                              | 133624          |     |        |     |         |
+| 27054280                                              | 134717          |     |        |     |         |
 | Function Name                                         | min             | avg | median | max | # calls |
-| wrapFlatFeeForOrder                                   | 553             | 553 | 553    | 553 | 140     |
+| wrapFlatFeeForOrder                                   | 553             | 553 | 553    | 553 | 138     |
 | test/utils/OrderSigUtils.sol:OrderSigUtils contract |                 |       |        |       |         |
 |-----------------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                                     | Deployment Size |       |        |       |         |
 | 411771                                              | 1839            |       |        |       |         |
 | Function Name                                       | min             | avg   | median | max   | # calls |
-| getOrderFeeQuoteToSign                              | 5902            | 5902  | 5902   | 5902  | 512     |
+| getOrderFeeQuoteToSign                              | 5924            | 5924  | 5924   | 5924  | 512     |
 | getOrderRequestHashToSign                           | 11919           | 15419 | 15419  | 18919 | 512     |
 | test/utils/SigUtils.sol:SigUtils contract |                 |      |        |      |         |
 |-------------------------------------------|-----------------|------|--------|------|---------|
@@ -301,15 +303,15 @@
 | test/utils/mocks/MockToken.sol:MockToken contract |                 |       |        |       |         |
 |---------------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                                   | Deployment Size |       |        |       |         |
-| 1656424                                           | 8628            |       |        |       |         |
+| 1656511                                           | 8628            |       |        |       |         |
 | Function Name                                     | min             | avg   | median | max   | # calls |
 | DOMAIN_SEPARATOR                                  | 394             | 394   | 394    | 394   | 40      |
 | allowance                                         | 776             | 2773  | 2776   | 2776  | 769     |
-| approve                                           | 26376           | 46408 | 46396  | 46660 | 2818    |
-| balanceOf                                         | 624             | 996   | 624    | 2624  | 8717    |
+| approve                                           | 26376           | 46409 | 46408  | 46660 | 2818    |
+| balanceOf                                         | 624             | 996   | 624    | 2624  | 8739    |
 | blacklist                                         | 90687           | 90687 | 90687  | 90687 | 512     |
-| decimals                                          | 244             | 244   | 244    | 244   | 622     |
+| decimals                                          | 244             | 244   | 244    | 244   | 625     |
 | isBlacklisted                                     | 615             | 2434  | 2615   | 2615  | 5686    |
-| mint                                              | 30632           | 70612 | 70708  | 71044 | 3846    |
+| mint                                              | 30632           | 70615 | 70708  | 71044 | 3846    |
 | nonces                                            | 590             | 590   | 590    | 590   | 1       |
-| transfer                                          | 28730           | 46556 | 46690  | 47014 | 512     |
+| transfer                                          | 28730           | 46557 | 46690  | 47014 | 512     |

--- a/.gas-report
+++ b/.gas-report
@@ -18,42 +18,42 @@
 | beginDefaultAdminTransfer                                                                 | 54990           | 54990  | 54990  | 54990  | 1       |
 | burn                                                                                      | 28760           | 36430  | 36237  | 52990  | 514     |
 | burnFrom                                                                                  | 46490           | 46973  | 46797  | 49952  | 256     |
-| cancelOrder                                                                               | 35489           | 104182 | 89660  | 121415 | 513     |
+| cancelOrder                                                                               | 35506           | 103435 | 86868  | 123008 | 513     |
 | convertToAssets                                                                           | 2851            | 2851   | 2851   | 2851   | 147     |
 | createDShare                                                                              | 32578           | 462743 | 700365 | 966734 | 562     |
-| createOrderStandardFees                                                                   | 30699           | 148552 | 165067 | 237906 | 6150    |
-| createOrderWithSignature                                                                  | 177619          | 200557 | 200676 | 223441 | 512     |
+| createOrderStandardFees                                                                   | 30699           | 150039 | 167307 | 240133 | 6150    |
+| createOrderWithSignature                                                                  | 179847          | 202782 | 202904 | 225669 | 512     |
 | dShareFactory                                                                             | 2769            | 2769   | 2769   | 2769   | 1       |
 | decimals                                                                                  | 726             | 726    | 726    | 726    | 1       |
 | deposit                                                                                   | 73317           | 128873 | 129113 | 131437 | 1026    |
-| fillOrder                                                                                 | 31923           | 152582 | 169101 | 275614 | 2803    |
+| fillOrder                                                                                 | 31923           | 147922 | 149365 | 255723 | 2803    |
 | getDShareBeacon                                                                           | 3264            | 3264   | 3264   | 3264   | 1       |
 | getDShares                                                                                | 3962            | 7712   | 7712   | 11462  | 512     |
 | getFeesEscrowed                                                                           | 884             | 884    | 884    | 884    | 256     |
-| getFeesTaken                                                                              | 884             | 884    | 884    | 884    | 99      |
-| getOrderStatus                                                                            | 983             | 984    | 983    | 3483   | 2474    |
-| getOrderTrackedAmount                                                                     | 1113            | 3528   | 5113   | 5113   | 424     |
+| getFeesTaken                                                                              | 906             | 906    | 906    | 906    | 94      |
+| getOrderStatus                                                                            | 983             | 984    | 983    | 3483   | 2462    |
 | getPaymentTokenConfig                                                                     | 6277            | 6277   | 6277   | 6277   | 256     |
+| getReceivedAmount                                                                         | 906             | 906    | 906    | 906    | 318     |
 | getStandardFees                                                                           | 2192            | 6361   | 8692   | 8692   | 2348    |
 | getTransferRestrictor                                                                     | 704             | 704    | 704    | 704    | 1       |
-| getUnfilledAmount                                                                         | 907             | 1604   | 907    | 7407   | 2385    |
+| getUnfilledAmount                                                                         | 907             | 1661   | 907    | 7407   | 2205    |
 | getWrappedDShareBeacon                                                                    | 714             | 714    | 714    | 714    | 1       |
 | grantRole                                                                                 | 56134           | 56347  | 56374  | 56374  | 2574    |
 | hasRole                                                                                   | 3605            | 5605   | 5605   | 7605   | 2       |
 | hashFeeQuote                                                                              | 1630            | 1630   | 1630   | 1630   | 512     |
 | hashOrder                                                                                 | 2644            | 3396   | 2644   | 7144   | 1537    |
-| hashOrderRequest                                                                          | 2966            | 2966   | 2966   | 2966   | 512     |
+| hashOrderRequest                                                                          | 2921            | 2921   | 2921   | 2921   | 512     |
 | initializeV2                                                                              | 28438           | 43077  | 43077  | 57716  | 2       |
 | isBlacklisted                                                                             | 1946            | 3536   | 3325   | 7204   | 1536    |
-| isOperator                                                                                | 5505            | 5505   | 5505   | 5505   | 256     |
+| isOperator                                                                                | 5527            | 5527   | 5527   | 5527   | 256     |
 | isTokenDShare                                                                             | 5543            | 7373   | 7543   | 7543   | 6032    |
 | isTokenWrappedDShare                                                                      | 1042            | 1042   | 1042   | 1042   | 512     |
 | isTransferLocked                                                                          | 2726            | 5976   | 5976   | 9226   | 512     |
-| latestFillPrice                                                                           | 1651            | 1651   | 1651   | 1651   | 355     |
+| latestFillPrice                                                                           | 1651            | 1651   | 1651   | 1651   | 350     |
 | maxWithdraw                                                                               | 3120            | 3120   | 3120   | 3120   | 5       |
 | mint(address,uint256)                                                                     | 29032           | 82102  | 88181  | 89049  | 4104    |
 | mint(uint256,address)                                                                     | 75354           | 129296 | 129246 | 131462 | 512     |
-| multicall                                                                                 | 258465          | 284342 | 274258 | 320258 | 770     |
+| multicall                                                                                 | 260705          | 286562 | 276486 | 322474 | 770     |
 | name                                                                                      | 1358            | 2918   | 3861   | 8040   | 513     |
 | orderDecimalReduction                                                                     | 1028            | 1028   | 1028   | 1028   | 1       |
 | ordersPaused                                                                              | 5253            | 5253   | 5253   | 5253   | 256     |
@@ -61,20 +61,20 @@
 | pendingDefaultAdmin                                                                       | 3285            | 3285   | 3285   | 3285   | 1       |
 | redeem                                                                                    | 67735           | 84076  | 87887  | 95247  | 513     |
 | removePaymentToken                                                                        | 28765           | 30618  | 30579  | 32394  | 512     |
-| requestCancel                                                                             | 28642           | 28777  | 28690  | 30580  | 258     |
+| requestCancel                                                                             | 28662           | 28814  | 28710  | 32774  | 258     |
 | revokeRole                                                                                | 26915           | 26915  | 26915  | 26915  | 1       |
 | selfPermit                                                                                | 55432           | 58721  | 55432  | 83584  | 771     |
 | setBalancePerShare                                                                        | 28804           | 34197  | 34912  | 35068  | 2050    |
 | setName                                                                                   | 29089           | 50262  | 36474  | 104663 | 768     |
 | setNewTransferRestrictor                                                                  | 26499           | 28301  | 28301  | 30103  | 2       |
-| setOperator                                                                               | 28964           | 42229  | 52605  | 52833  | 817     |
-| setOrderDecimalReduction                                                                  | 52865           | 52865  | 52865  | 52865  | 1       |
+| setOperator                                                                               | 28976           | 42227  | 52605  | 52833  | 817     |
+| setOrderDecimalReduction                                                                  | 52821           | 52821  | 52821  | 52821  | 1       |
 | setOrdersPaused                                                                           | 28709           | 32325  | 34779  | 34779  | 768     |
 | setPaymentToken                                                                           | 30076           | 48397  | 62580  | 64270  | 1073    |
 | setSymbol                                                                                 | 29079           | 50244  | 36454  | 104631 | 768     |
 | setTransferRestrictor                                                                     | 30159           | 31399  | 30159  | 35199  | 1024    |
-| setTreasury                                                                               | 28732           | 31955  | 28960  | 35124  | 513     |
-| setVault                                                                                  | 28755           | 31984  | 28983  | 35159  | 513     |
+| setTreasury                                                                               | 28732           | 31954  | 28960  | 35124  | 513     |
+| setVault                                                                                  | 28777           | 32005  | 29005  | 35181  | 513     |
 | sharesToBalance                                                                           | 1117            | 1129   | 1117   | 1197   | 768     |
 | symbol                                                                                    | 1379            | 2918   | 3561   | 4429   | 513     |
 | totalSupply                                                                               | 1147            | 1154   | 1147   | 1227   | 1283    |
@@ -92,13 +92,13 @@
 | BURNER_ROLE                                                                            | 1187            | 1187  | 1187   | 1187  | 46      |
 | DOMAIN_SEPARATOR                                                                       | 2203            | 2203  | 2203   | 2203  | 2       |
 | MINTER_ROLE                                                                            | 1208            | 1208  | 1208   | 1208  | 96      |
-| approve                                                                                | 36888           | 54082 | 54084  | 54300 | 1794    |
+| approve                                                                                | 36888           | 54085 | 54096  | 54300 | 1794    |
 | asset                                                                                  | 1349            | 6684  | 10349  | 10349 | 1537    |
-| balanceOf                                                                              | 1896            | 3398  | 1896   | 12896 | 3526    |
+| balanceOf                                                                              | 1896            | 3397  | 1896   | 12896 | 3516    |
 | decimals                                                                               | 8213            | 8213  | 8213   | 8213  | 1       |
 | grantRole                                                                              | 59415           | 59423 | 59427  | 59427 | 142     |
 | isBlacklisted                                                                          | 4499            | 15118 | 15999  | 15999 | 5381    |
-| mint                                                                                   | 57298           | 91672 | 91618  | 92102 | 1794    |
+| mint                                                                                   | 57298           | 91676 | 91618  | 92102 | 1794    |
 | name                                                                                   | 1914            | 3606  | 2318   | 10480 | 768     |
 | owner                                                                                  | 1316            | 1337  | 1337   | 1359  | 512     |
 | symbol                                                                                 | 1910            | 5932  | 2336   | 17476 | 768     |
@@ -108,15 +108,15 @@
 | Deployment Cost                                                                                    | Deployment Size |      |        |      |         |
 | 305890                                                                                             | 1389            |      |        |      |         |
 | Function Name                                                                                      | min             | avg  | median | max  | # calls |
-| implementation                                                                                     | 306             | 1424 | 2306   | 2306 | 22577   |
+| implementation                                                                                     | 306             | 1424 | 2306   | 2306 | 22562   |
 | lib/solady/test/utils/mocks/MockERC20.sol:MockERC20 contract |                 |       |        |       |         |
 |--------------------------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                                              | Deployment Size |       |        |       |         |
 | 765980                                                       | 3890            |       |        |       |         |
 | Function Name                                                | min             | avg   | median | max   | # calls |
-| approve                                                      | 26057           | 45844 | 45993  | 46341 | 1024    |
+| approve                                                      | 26057           | 45845 | 45993  | 46341 | 1024    |
 | balanceOf                                                    | 596             | 899   | 596    | 2596  | 1688    |
-| decimals                                                     | 311             | 1681  | 2311   | 2311  | 375     |
+| decimals                                                     | 311             | 1674  | 2311   | 2311  | 377     |
 | mint                                                         | 28108           | 67619 | 68052  | 68520 | 1024    |
 | src/DShare.sol:DShare contract |                 |        |        |        |         |
 |--------------------------------|-----------------|--------|--------|--------|---------|
@@ -130,7 +130,7 @@
 | acceptDefaultAdminTransfer     | 2406            | 16110  | 2622   | 43302  | 3       |
 | allowance                      | 668             | 668    | 668    | 668    | 256     |
 | approve                        | 4525            | 24292  | 24425  | 24425  | 3588    |
-| balanceOf                      | 968             | 2314   | 968    | 4968   | 9463    |
+| balanceOf                      | 968             | 2314   | 968    | 4968   | 9453    |
 | balancePerShare                | 430             | 430    | 430    | 430    | 256     |
 | balanceToShares                | 765             | 811    | 765    | 1057   | 512     |
 | beginDefaultAdminTransfer      | 28914           | 28914  | 28914  | 28914  | 1       |
@@ -141,7 +141,7 @@
 | hasRole                        | 727             | 1727   | 1727   | 2727   | 2       |
 | initialize                     | 143757          | 203970 | 208067 | 274648 | 591     |
 | isBlacklisted                  | 596             | 6774   | 8071   | 8071   | 6405    |
-| mint                           | 2815            | 58437  | 61938  | 62230  | 7264    |
+| mint                           | 2815            | 58435  | 61938  | 62230  | 7259    |
 | name                           | 986             | 2661   | 1384   | 9543   | 768     |
 | owner                          | 434             | 434    | 434    | 434    | 257     |
 | pendingDefaultAdmin            | 410             | 410    | 410    | 410    | 1       |
@@ -181,7 +181,7 @@
 | RESTRICTOR_ROLE                                        | 284             | 284   | 284    | 284   | 322     |
 | grantRole                                              | 51215           | 51215 | 51215  | 51215 | 66      |
 | isBlacklisted                                          | 593             | 2208  | 2593   | 2593  | 6661    |
-| requireNotRestricted                                   | 675             | 4194  | 4829   | 4860  | 16231   |
+| requireNotRestricted                                   | 675             | 4194  | 4829   | 4860  | 16226   |
 | restrict                                               | 23922           | 43976 | 47205  | 47433 | 1792    |
 | unrestrict                                             | 25309           | 25468 | 25549  | 25549 | 256     |
 | src/WrappedDShare.sol:WrappedDShare contract |                 |        |        |        |         |
@@ -223,51 +223,51 @@
 | src/orders/FulfillmentRouter.sol:FulfillmentRouter contract |                 |        |        |        |         |
 |-------------------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                             | Deployment Size |        |        |        |         |
-| 1848570                                                     | 8623            |        |        |        |         |
+| 1848558                                                     | 8623            |        |        |        |         |
 | Function Name                                               | min             | avg    | median | max    | # calls |
 | OPERATOR_ROLE                                               | 282             | 282    | 282    | 282    | 6       |
-| cancelBuyOrder                                              | 28204           | 84611  | 79839  | 141096 | 512     |
-| fillOrder                                                   | 27373           | 252644 | 256640 | 277207 | 514     |
+| cancelBuyOrder                                              | 28204           | 80321  | 75516  | 132451 | 512     |
+| fillOrder                                                   | 27373           | 236972 | 240823 | 257315 | 514     |
 | grantRole                                                   | 51331           | 51331  | 51331  | 51331  | 5       |
 | src/orders/OrderProcessor.sol:OrderProcessor contract |                 |        |        |        |         |
 |-------------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                       | Deployment Size |        |        |        |         |
-| 5126831                                               | 23753           |        |        |        |         |
+| 5121180                                               | 23725           |        |        |        |         |
 | Function Name                                         | min             | avg    | median | max    | # calls |
 | DOMAIN_SEPARATOR                                      | 2433            | 4433   | 4433   | 6433   | 1024    |
-| cancelOrder                                           | 6880            | 83098  | 81640  | 101086 | 769     |
-| createOrderStandardFees                               | 2564            | 128900 | 151141 | 219072 | 6150    |
-| createOrderWithSignature                              | 177090          | 200028 | 200147 | 222912 | 512     |
+| cancelOrder                                           | 6897            | 73285  | 70833  | 93079  | 769     |
+| createOrderStandardFees                               | 2564            | 130386 | 153369 | 221299 | 6150    |
+| createOrderWithSignature                              | 179318          | 202253 | 202375 | 225140 | 512     |
 | dShareFactory                                         | 2397            | 2397   | 2397   | 2397   | 1       |
-| fillOrder                                             | 2738            | 143979 | 195411 | 246085 | 3315    |
+| fillOrder                                             | 2738            | 136728 | 167368 | 231175 | 3315    |
 | getFeesEscrowed                                       | 509             | 509    | 509    | 509    | 256     |
-| getFeesTaken                                          | 509             | 509    | 509    | 509    | 99      |
-| getOrderStatus                                        | 608             | 608    | 608    | 608    | 2474    |
-| getOrderTrackedAmount                                 | 735             | 3150   | 4735   | 4735   | 424     |
+| getFeesTaken                                          | 531             | 531    | 531    | 531    | 94      |
+| getOrderStatus                                        | 608             | 608    | 608    | 608    | 2462    |
 | getPaymentTokenConfig                                 | 1372            | 1372   | 1372   | 1372   | 256     |
+| getReceivedAmount                                     | 531             | 531    | 531    | 531    | 318     |
 | getStandardFees                                       | 1045            | 3036   | 3811   | 3811   | 2348    |
-| getUnfilledAmount                                     | 532             | 746    | 532    | 2532   | 2385    |
+| getUnfilledAmount                                     | 532             | 764    | 532    | 2532   | 2205    |
 | hashFeeQuote                                          | 1234            | 1234   | 1234   | 1234   | 512     |
 | hashOrder                                             | 2218            | 2218   | 2218   | 2218   | 1537    |
-| hashOrderRequest                                      | 2534            | 2534   | 2534   | 2534   | 512     |
+| hashOrderRequest                                      | 2489            | 2489   | 2489   | 2489   | 512     |
 | initialize                                            | 99773           | 163629 | 167537 | 167537 | 52      |
-| isOperator                                            | 630             | 630    | 630    | 630    | 256     |
+| isOperator                                            | 652             | 652    | 652    | 652    | 256     |
 | isTransferLocked                                      | 2348            | 3348   | 3348   | 4348   | 512     |
-| latestFillPrice                                       | 1270            | 1270   | 1270   | 1270   | 355     |
-| multicall                                             | 246810          | 263894 | 261991 | 282835 | 770     |
+| latestFillPrice                                       | 1270            | 1270   | 1270   | 1270   | 350     |
+| multicall                                             | 249038          | 266120 | 264219 | 285063 | 770     |
 | orderDecimalReduction                                 | 653             | 653    | 653    | 653    | 1       |
 | ordersPaused                                          | 381             | 381    | 381    | 381    | 256     |
 | owner                                                 | 2459            | 2459   | 2459   | 2459   | 1       |
 | proxiableUUID                                         | 343             | 343    | 343    | 343    | 1       |
 | removePaymentToken                                    | 2694            | 4392   | 4392   | 6090   | 512     |
-| requestCancel                                         | 2574            | 2580   | 2574   | 4132   | 258     |
+| requestCancel                                         | 2594            | 2617   | 2594   | 6326   | 258     |
 | selfPermit                                            | 55027           | 58279  | 55027  | 64824  | 771     |
 | setOperator                                           | 2762            | 15914  | 26386  | 26386  | 817     |
-| setOrderDecimalReduction                              | 26418           | 26418  | 26418  | 26418  | 1       |
+| setOrderDecimalReduction                              | 26374           | 26374  | 26374  | 26374  | 1       |
 | setOrdersPaused                                       | 2638            | 6251   | 8703   | 8703   | 768     |
 | setPaymentToken                                       | 3050            | 21260  | 35489  | 36987  | 1073    |
 | setTreasury                                           | 2649            | 5728   | 2664   | 8820   | 513     |
-| setVault                                              | 2672            | 5757   | 2687   | 8855   | 513     |
+| setVault                                              | 2694            | 5779   | 2709   | 8877   | 513     |
 | treasury                                              | 426             | 433    | 426    | 2426   | 257     |
 | upgradeToAndCall                                      | 3287            | 7145   | 7145   | 11003  | 2       |
 | vault                                                 | 418             | 425    | 418    | 2418   | 257     |
@@ -284,16 +284,16 @@
 | test/OrderProcessor.t.sol:OrderProcessorTest contract |                 |     |        |     |         |
 |-------------------------------------------------------|-----------------|-----|--------|-----|---------|
 | Deployment Cost                                       | Deployment Size |     |        |     |         |
-| 27054280                                              | 134717          |     |        |     |         |
+| 26938677                                              | 134141          |     |        |     |         |
 | Function Name                                         | min             | avg | median | max | # calls |
-| wrapFlatFeeForOrder                                   | 553             | 553 | 553    | 553 | 138     |
+| wrapFlatFeeForOrder                                   | 553             | 553 | 553    | 553 | 136     |
 | test/utils/OrderSigUtils.sol:OrderSigUtils contract |                 |       |        |       |         |
 |-----------------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                                     | Deployment Size |       |        |       |         |
 | 411771                                              | 1839            |       |        |       |         |
 | Function Name                                       | min             | avg   | median | max   | # calls |
 | getOrderFeeQuoteToSign                              | 5924            | 5924  | 5924   | 5924  | 512     |
-| getOrderRequestHashToSign                           | 11919           | 15419 | 15419  | 18919 | 512     |
+| getOrderRequestHashToSign                           | 11874           | 15374 | 15374  | 18874 | 512     |
 | test/utils/SigUtils.sol:SigUtils contract |                 |      |        |      |         |
 |-------------------------------------------|-----------------|------|--------|------|---------|
 | Deployment Cost                           | Deployment Size |      |        |      |         |
@@ -308,10 +308,10 @@
 | DOMAIN_SEPARATOR                                  | 394             | 394   | 394    | 394   | 40      |
 | allowance                                         | 776             | 2773  | 2776   | 2776  | 769     |
 | approve                                           | 26376           | 46409 | 46408  | 46660 | 2818    |
-| balanceOf                                         | 624             | 996   | 624    | 2624  | 8739    |
+| balanceOf                                         | 624             | 996   | 624    | 2624  | 8694    |
 | blacklist                                         | 90687           | 90687 | 90687  | 90687 | 512     |
-| decimals                                          | 244             | 244   | 244    | 244   | 625     |
+| decimals                                          | 244             | 244   | 244    | 244   | 619     |
 | isBlacklisted                                     | 615             | 2434  | 2615   | 2615  | 5686    |
-| mint                                              | 30632           | 70615 | 70708  | 71044 | 3846    |
+| mint                                              | 30632           | 70614 | 70708  | 71044 | 3846    |
 | nonces                                            | 590             | 590   | 590    | 590   | 1       |
 | transfer                                          | 28730           | 46557 | 46690  | 47014 | 512     |

--- a/sizes.txt
+++ b/sizes.txt
@@ -28,7 +28,7 @@ No files changed, compilation skipped
 | NumberUtils              |       85 |     24,491 |
 | Operator                 |    1,744 |     22,832 |
 | OracleLib                |       85 |     24,491 |
-| OrderProcessor           |   23,504 |      1,072 |
+| OrderProcessor           |   23,476 |      1,100 |
 | OrderSigUtils            |    1,661 |     22,915 |
 | Pausable                 |      150 |     24,426 |
 | RolesBase                |      401 |     24,175 |

--- a/sizes.txt
+++ b/sizes.txt
@@ -28,7 +28,7 @@ No files changed, compilation skipped
 | NumberUtils              |       85 |     24,491 |
 | Operator                 |    1,744 |     22,832 |
 | OracleLib                |       85 |     24,491 |
-| OrderProcessor           |   23,321 |      1,255 |
+| OrderProcessor           |   23,504 |      1,072 |
 | OrderSigUtils            |    1,661 |     22,915 |
 | Pausable                 |      150 |     24,426 |
 | RolesBase                |      401 |     24,175 |

--- a/src/orders/IOrderProcessor.sol
+++ b/src/orders/IOrderProcessor.sol
@@ -94,12 +94,6 @@ interface IOrderProcessor {
         uint64 blocktime;
     }
 
-    struct OrderTracking {
-        // Fill tracking for order
-        uint256 unfilledAmount;
-        uint256 receivedAmount;
-    }
-
     /// @dev Emitted order details and order ID for each order
     event OrderCreated(uint256 indexed id, address indexed requester, Order order, uint256 feesEscrowed);
     /// @dev Emitted for each fill
@@ -135,9 +129,9 @@ interface IOrderProcessor {
     /// @param id Order ID
     function getUnfilledAmount(uint256 id) external view returns (uint256);
 
-    /// @notice Get unfilled and received amounts for an order
+    /// @notice Get received amount for an order
     /// @param id Order ID
-    function getOrderTrackedAmount(uint256 id) external view returns (uint256, uint256);
+    function getReceivedAmount(uint256 id) external view returns (uint256);
 
     /// @notice Get fees in payment token escrowed for a buy order
     /// @param id Order ID

--- a/src/orders/IOrderProcessor.sol
+++ b/src/orders/IOrderProcessor.sol
@@ -94,6 +94,12 @@ interface IOrderProcessor {
         uint64 blocktime;
     }
 
+    struct OrderTracking {
+        // Fill tracking for order
+        uint256 unfilledAmount;
+        uint256 receivedAmount;
+    }
+
     /// @dev Emitted order details and order ID for each order
     event OrderCreated(uint256 indexed id, address indexed requester, Order order, uint256 feesEscrowed);
     /// @dev Emitted for each fill
@@ -128,6 +134,10 @@ interface IOrderProcessor {
     /// @notice Get remaining order quantity to fill
     /// @param id Order ID
     function getUnfilledAmount(uint256 id) external view returns (uint256);
+
+    /// @notice Get unfilled and received amounts for an order
+    /// @param id Order ID
+    function getOrderTrackedAmount(uint256 id) external view returns (uint256, uint256);
 
     /// @notice Get fees in payment token escrowed for a buy order
     /// @param id Order ID

--- a/src/orders/OrderProcessor.sol
+++ b/src/orders/OrderProcessor.sol
@@ -132,14 +132,14 @@ contract OrderProcessor is
         mapping(uint256 => OrderStatus) _status;
         // Active order state
         mapping(uint256 => OrderState) _orders;
-        // Order tracking
-        mapping(uint256 => OrderTracking) _tracking;
         // Reduciton of order decimals for asset token, defaults to 0
         mapping(address => uint8) _orderDecimalReduction;
         // Payment token configuration data
         mapping(address => PaymentTokenConfig) _paymentTokens;
         // Latest pairwise price
         mapping(bytes32 => PricePoint) _latestFillPrice;
+        // Order tracking
+        mapping(uint256 => OrderTracking) _tracking;
     }
 
     // keccak256(abi.encode(uint256(keccak256("dinaricrypto.storage.OrderProcessor")) - 1)) & ~bytes32(uint256(0xff))

--- a/src/orders/OrderProcessor.sol
+++ b/src/orders/OrderProcessor.sol
@@ -47,6 +47,8 @@ contract OrderProcessor is
         uint256 feesEscrowed;
         // Cumulative fees taken for order
         uint256 feesTaken;
+        // Amount of token received from fills
+        uint256 receivedAmount;
     }
 
     struct PaymentTokenConfig {
@@ -70,8 +72,7 @@ contract OrderProcessor is
     error Paused();
     /// @dev Zero value
     error ZeroValue();
-    /// @dev Order does not exist
-    error OrderNotFound();
+    error OrderNotActive();
     error ExistingOrder();
     /// @dev Amount too large
     error AmountTooLarge();
@@ -138,8 +139,6 @@ contract OrderProcessor is
         mapping(address => PaymentTokenConfig) _paymentTokens;
         // Latest pairwise price
         mapping(bytes32 => PricePoint) _latestFillPrice;
-        // Order tracking
-        mapping(uint256 => OrderTracking) _tracking;
     }
 
     // keccak256(abi.encode(uint256(keccak256("dinaricrypto.storage.OrderProcessor")) - 1)) & ~bytes32(uint256(0xff))
@@ -232,10 +231,9 @@ contract OrderProcessor is
     }
 
     /// @inheritdoc IOrderProcessor
-    function getOrderTrackedAmount(uint256 id) external view returns (uint256, uint256) {
+    function getReceivedAmount(uint256 id) external view returns (uint256) {
         OrderProcessorStorage storage $ = _getOrderProcessorStorage();
-        OrderTracking memory tracking = $._tracking[id];
-        return (tracking.unfilledAmount, tracking.receivedAmount);
+        return $._orders[id].receivedAmount;
     }
 
     /// @inheritdoc IOrderProcessor
@@ -520,8 +518,13 @@ contract OrderProcessor is
         // ------------------ Effects ------------------ //
 
         // Initialize order state
-        $._orders[id] =
-            OrderState({requester: requester, unfilledAmount: orderAmount, feesEscrowed: feesEscrowed, feesTaken: 0});
+        $._orders[id] = OrderState({
+            requester: requester,
+            unfilledAmount: orderAmount,
+            feesEscrowed: feesEscrowed,
+            feesTaken: 0,
+            receivedAmount: 0
+        });
         $._status[id] = OrderStatus.ACTIVE;
 
         emit OrderCreated(id, requester, order, feesEscrowed);
@@ -615,8 +618,8 @@ contract OrderProcessor is
         OrderProcessorStorage storage $ = _getOrderProcessorStorage();
         OrderState memory orderState = $._orders[id];
 
-        // Order must exist
-        if (orderState.requester == address(0)) revert OrderNotFound();
+        // Order must be active
+        if ($._status[id] != OrderStatus.ACTIVE) revert OrderNotActive();
         // Fill cannot exceed remaining order
         if (fillAmount > orderState.unfilledAmount) revert AmountTooLarge();
 
@@ -653,7 +656,7 @@ contract OrderProcessor is
 
         _publishFill(id, orderState.requester, order, assetAmount, paymentAmount, fees);
 
-        _updateFillState(id, orderState, assetAmount, fees, paymentAmount);
+        _updateFillState(id, orderState, assetAmount, paymentAmount, fees);
 
         // Transfer the received amount from the filler to this contract
         IERC20(order.paymentToken).safeTransferFrom(msg.sender, address(this), paymentAmount);
@@ -688,7 +691,7 @@ contract OrderProcessor is
 
         _publishFill(id, orderState.requester, order, assetAmount, paymentAmount, fees);
 
-        bool fulfilled = _updateFillState(id, orderState, paymentAmount, fees, assetAmount);
+        bool fulfilled = _updateFillState(id, orderState, paymentAmount, assetAmount, fees);
 
         // Update fee escrow (and refund if eligible)
         uint256 remainingFeesEscrowed = orderState.feesEscrowed - fees;
@@ -735,37 +738,33 @@ contract OrderProcessor is
         uint256 id,
         OrderState memory orderState,
         uint256 fillAmount,
-        uint256 fees,
-        uint256 receivedAmount
+        uint256 receivedAmount,
+        uint256 fees
     ) private returns (bool fulfilled) {
         OrderProcessorStorage storage $ = _getOrderProcessorStorage();
 
         // Update order state
         uint256 newUnfilledAmount = orderState.unfilledAmount - fillAmount;
+        $._orders[id].unfilledAmount = newUnfilledAmount;
+        $._orders[id].receivedAmount = orderState.receivedAmount + receivedAmount;
+        $._orders[id].feesTaken = orderState.feesTaken + fees;
         // If order is completely filled then clear order state
         fulfilled = newUnfilledAmount == 0;
-        $._tracking[id].unfilledAmount = newUnfilledAmount;
-        $._tracking[id].receivedAmount += receivedAmount;
         if (fulfilled) {
+            $._orders[id].feesEscrowed = 0;
             $._status[id] = OrderStatus.FULFILLED;
-            // Clear order state
-            delete $._orders[id];
             // Notify order fulfilled
             emit OrderFulfilled(id, orderState.requester);
-        } else {
-            // Otherwise update order state
-            $._orders[id].unfilledAmount = newUnfilledAmount;
-            $._orders[id].feesTaken = orderState.feesTaken + fees;
         }
     }
 
     /// @inheritdoc IOrderProcessor
     function requestCancel(uint256 id) external {
         OrderProcessorStorage storage $ = _getOrderProcessorStorage();
-        // Order must exist
-        address requester = $._orders[id].requester;
-        if (requester == address(0)) revert OrderNotFound();
+        // Order must be active
+        if ($._status[id] != OrderStatus.ACTIVE) revert OrderNotActive();
         // Only requester can request cancellation
+        address requester = $._orders[id].requester;
         if (requester != msg.sender) revert NotRequester();
 
         // Send cancel request to bridge
@@ -780,24 +779,23 @@ contract OrderProcessor is
         uint256 id = hashOrder(order);
 
         OrderProcessorStorage storage $ = _getOrderProcessorStorage();
-        OrderState storage orderState = $._orders[id];
-        address requester = orderState.requester;
-        // Order must exist
-        if (requester == address(0)) revert OrderNotFound();
+        // Order must be active
+        if ($._status[id] != OrderStatus.ACTIVE) revert OrderNotActive();
 
         // ------------------ Effects ------------------ //
 
         // If buy order, then refund fee deposit
+        OrderState storage orderState = $._orders[id];
         uint256 feeRefund = order.sell ? 0 : orderState.feesEscrowed;
         uint256 unfilledAmount = orderState.unfilledAmount;
+
+        orderState.feesEscrowed = 0;
 
         // Order is cancelled
         $._status[id] = OrderStatus.CANCELLED;
 
-        // Clear order state
-        delete $._orders[id];
-
         // Notify order cancelled
+        address requester = orderState.requester;
         emit OrderCancelled(id, requester, reason);
 
         // ------------------ Interactions ------------------ //


### PR DESCRIPTION
Integrate functionality to persist unfilledAmount and receivedAmount for each order in the OrderProcessor contract, ensuring the existing storage map is preserved during the in-place upgrade.