### PR TITLE
chore: remove limit buy precision checks from examples

### DIFF
--- a/script/examples/create_order.ts
+++ b/script/examples/create_order.ts
@@ -120,8 +120,8 @@ async function main() {
   const limitPrice = Number(0);
 
   // check the order precision doesn't exceed max decimals
-  // applicable to sell and limit orders only
-  if (sellOrder || orderType === 1) {
+  // applicable to sell orders only
+  if (sellOrder) {
     const allowedDecimalReduction = await orderProcessor.orderDecimalReduction(assetTokenAddress);
     const allowablePrecisionReduction = 10 ** allowedDecimalReduction;
     if (Number(orderAmount) % allowablePrecisionReduction != 0) {

--- a/script/examples/create_order_approve.ts
+++ b/script/examples/create_order_approve.ts
@@ -78,8 +78,8 @@ async function main() {
     const orderType = Number(0);
 
     // check the order precision doesn't exceed max decimals
-    // applicable to sell and limit orders only
-    if (sellOrder || orderType === 1) {
+    // applicable to sell orders only
+    if (sellOrder) {
         const allowedDecimalReduction = await orderProcessor.orderDecimalReduction(assetTokenAddress);
         const allowablePrecisionReduction = 10 ** allowedDecimalReduction;
         if (Number(orderAmount) % allowablePrecisionReduction != 0) {

--- a/script/examples/create_order_standardfees.ts
+++ b/script/examples/create_order_standardfees.ts
@@ -65,8 +65,8 @@ async function main() {
     const orderType = Number(0);
 
     // check the order precision doesn't exceed max decimals
-    // applicable to sell and limit orders only
-    if (sellOrder || orderType === 1) {
+    // applicable to sell orders only
+    if (sellOrder) {
         const allowedDecimalReduction = await orderProcessor.orderDecimalReduction(assetTokenAddress);
         const allowablePrecisionReduction = 10 ** allowedDecimalReduction;
         if (Number(orderAmount) % allowablePrecisionReduction != 0) {


### PR DESCRIPTION
Remove unnecessary precision check