### PR TITLE
[DSHARE-923] Update Plume-nest dependencies and add AssetsOf method

### DIFF
--- a/src/plume-nest/DinariAdapterToken.sol
+++ b/src/plume-nest/DinariAdapterToken.sol
@@ -99,11 +99,6 @@ contract DinariAdapterToken is ComponentToken {
     // Override Functions
 
     /// @inheritdoc IComponentToken
-    function assetsOf(address owner) public view override(ComponentToken) returns (uint256 assets) {
-        return convertToAssets(balanceOf(owner));
-    }
-
-    /// @inheritdoc IComponentToken
     function convertToShares(uint256 assets) public view override(ComponentToken) returns (uint256 shares) {
         // Apply dshare price and wrapped conversion rate, fees
         DinariAdapterTokenStorage storage $ = _getDinariAdapterTokenStorage();
@@ -148,7 +143,6 @@ contract DinariAdapterToken is ComponentToken {
     function requestDeposit(uint256 assets, address controller, address owner)
         public
         override(ComponentToken)
-        nonReentrant
         returns (uint256 requestId)
     {
         // Input must be more than flat fee
@@ -190,7 +184,6 @@ contract DinariAdapterToken is ComponentToken {
     function requestRedeem(uint256 shares, address controller, address owner)
         public
         override(ComponentToken)
-        nonReentrant
         returns (uint256 requestId)
     {
         DinariAdapterTokenStorage storage $ = _getDinariAdapterTokenStorage();
@@ -257,7 +250,7 @@ contract DinariAdapterToken is ComponentToken {
         return uint256($.submittedOrders.front());
     }
 
-    function processSubmittedOrders() public nonReentrant {
+    function processSubmittedOrders() public {
         DinariAdapterTokenStorage storage $ = _getDinariAdapterTokenStorage();
         IOrderProcessor orderContract = $.externalOrderContract;
         address nestStakingContract = $.nestStakingContract;
@@ -328,7 +321,7 @@ contract DinariAdapterToken is ComponentToken {
     }
 
     /// @dev Single order processing if gas limit is reached
-    function processNextSubmittedOrder() public nonReentrant {
+    function processNextSubmittedOrder() public {
         DinariAdapterTokenStorage storage $ = _getDinariAdapterTokenStorage();
         IOrderProcessor orderContract = $.externalOrderContract;
         address nestStakingContract = $.nestStakingContract;
@@ -355,7 +348,6 @@ contract DinariAdapterToken is ComponentToken {
     function deposit(uint256 assets, address receiver, address controller)
         public
         override(ComponentToken)
-        nonReentrant
         returns (uint256 shares)
     {
         DinariAdapterTokenStorage storage $ = _getDinariAdapterTokenStorage();
@@ -370,7 +362,6 @@ contract DinariAdapterToken is ComponentToken {
     function mint(uint256 shares, address receiver, address controller)
         public
         override(ComponentToken)
-        nonReentrant
         returns (uint256 assets)
     {
         DinariAdapterTokenStorage storage $ = _getDinariAdapterTokenStorage();
@@ -385,7 +376,6 @@ contract DinariAdapterToken is ComponentToken {
     function redeem(uint256 shares, address receiver, address controller)
         public
         override(ComponentToken)
-        nonReentrant
         returns (uint256 assets)
     {
         DinariAdapterTokenStorage storage $ = _getDinariAdapterTokenStorage();
@@ -400,7 +390,6 @@ contract DinariAdapterToken is ComponentToken {
     function withdraw(uint256 assets, address receiver, address controller)
         public
         override(ComponentToken)
-        nonReentrant
         returns (uint256 shares)
     {
         DinariAdapterTokenStorage storage $ = _getDinariAdapterTokenStorage();

--- a/src/plume-nest/DinariAdapterToken.sol
+++ b/src/plume-nest/DinariAdapterToken.sol
@@ -102,6 +102,11 @@ contract DinariAdapterToken is ComponentToken, ReentrancyGuardTransientUpgradeab
     // Override Functions
 
     /// @inheritdoc IComponentToken
+    function assetsOf(address owner) public view override(ComponentToken) returns (uint256 assets) {
+        return convertToAssets(balanceOf(owner));
+    }
+
+    /// @inheritdoc IComponentToken
     function convertToShares(uint256 assets) public view override(ComponentToken) returns (uint256 shares) {
         // Apply dshare price and wrapped conversion rate, fees
         DinariAdapterTokenStorage storage $ = _getDinariAdapterTokenStorage();

--- a/src/plume-nest/DinariAdapterToken.sol
+++ b/src/plume-nest/DinariAdapterToken.sol
@@ -5,8 +5,8 @@ import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {DoubleEndedQueue} from "@openzeppelin/contracts/utils/structs/DoubleEndedQueue.sol";
-import {ReentrancyGuardTransientUpgradeable} from
-    "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardTransientUpgradeable.sol";
+// import {ReentrancyGuardTransientUpgradeable} from 
+//     "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardTransientUpgradeable.sol";
 
 import {ComponentToken, IERC7540} from "plume-contracts/nest/src/ComponentToken.sol";
 import {IComponentToken} from "plume-contracts/nest/src/interfaces/IComponentToken.sol";
@@ -18,7 +18,7 @@ import {IOrderProcessor} from "../orders/IOrderProcessor.sol";
  * @notice Implementation of the abstract ComponentToken that interfaces with external assets.
  * @dev Asset is USDC. Holds wrapped dShares to accumulate yield.
  */
-contract DinariAdapterToken is ComponentToken, ReentrancyGuardTransientUpgradeable {
+contract DinariAdapterToken is ComponentToken {
     using DoubleEndedQueue for DoubleEndedQueue.Bytes32Deque;
 
     // Storage

--- a/src/plume-nest/DinariAdapterToken.sol
+++ b/src/plume-nest/DinariAdapterToken.sol
@@ -5,9 +5,6 @@ import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {DoubleEndedQueue} from "@openzeppelin/contracts/utils/structs/DoubleEndedQueue.sol";
-// import {ReentrancyGuardTransientUpgradeable} from 
-//     "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardTransientUpgradeable.sol";
-
 import {ComponentToken, IERC7540} from "plume-contracts/nest/src/ComponentToken.sol";
 import {IComponentToken} from "plume-contracts/nest/src/interfaces/IComponentToken.sol";
 import {IOrderProcessor} from "../orders/IOrderProcessor.sol";


### PR DESCRIPTION
[https://dinari.atlassian.net/browse/DSHARE-923](https://dinari.atlassian.net/browse/DSHARE-923)

Plume updated their ComponentToken interface. Update the plume repo dependency and add assetdOf method to [https://github.com/dinaricrypto/sbt-contracts/blob/feature/plume-nest/src/plume-nest/DinariAdapterToken.sol](https://github.com/dinaricrypto/sbt-contracts/blob/feature/plume-nest/src/plume-nest/DinariAdapterToken.sol )

