### PR TITLE
[DSHARE-977] L-05 Update balanceToShares with FixedPointMathLib

### DIFF
--- a/src/ERC20Rebasing.sol
+++ b/src/ERC20Rebasing.sol
@@ -40,7 +40,8 @@ abstract contract ERC20Rebasing is ERC20 {
     function maxSupply() public view virtual returns (uint256) {
         uint128 balancePerShare_ = balancePerShare();
         if (balancePerShare_ < _INITIAL_BALANCE_PER_SHARE) {
-            return FixedPointMathLib.mulWad(type(uint256).max, balancePerShare_);
+            // WAD = 1e18
+            return FixedPointMathLib.fullMulDiv(type(uint256).max, balancePerShare_, 1e18);
         } else if (balancePerShare_ > _INITIAL_BALANCE_PER_SHARE) {
             return FixedPointMathLib.fullMulDiv(type(uint256).max, _INITIAL_BALANCE_PER_SHARE, balancePerShare_);
         }

--- a/src/ERC20Rebasing.sol
+++ b/src/ERC20Rebasing.sol
@@ -37,10 +37,13 @@ abstract contract ERC20Rebasing is ERC20 {
     }
 
     function maxSupply() public view virtual returns (uint256) {
+        // Reduced maxSupply of shares to prevent overflow in balanceToShares and other functions
         uint128 balancePerShare_ = balancePerShare();
         if (balancePerShare_ < _INITIAL_BALANCE_PER_SHARE) {
+            // maxSupply = type(uint256).max * balancePerShare_ / _INITIAL_BALANCE_PER_SHARE
             return FixedPointMathLib.fullMulDiv(type(uint256).max, balancePerShare_, _INITIAL_BALANCE_PER_SHARE);
         } else if (balancePerShare_ > _INITIAL_BALANCE_PER_SHARE) {
+            // maxSupply = type(uint256).max * _INITIAL_BALANCE_PER_SHARE / balancePerShare_
             return FixedPointMathLib.fullMulDiv(type(uint256).max, _INITIAL_BALANCE_PER_SHARE, balancePerShare_);
         }
         return type(uint256).max;
@@ -110,7 +113,7 @@ abstract contract ERC20Rebasing is ERC20 {
         }
         // Check overflow
         if (totalSharesAfter < totalSharesBefore) revert TotalSupplyOverflow();
-        // Check total supply limit
+        // Check total supply limit, same as maxSupply logic
         uint128 balancePerShare_ = balancePerShare();
         if (
             balancePerShare_ > _INITIAL_BALANCE_PER_SHARE

--- a/src/ERC20Rebasing.sol
+++ b/src/ERC20Rebasing.sol
@@ -23,6 +23,7 @@ abstract contract ERC20Rebasing is ERC20 {
     function balancePerShare() public view virtual returns (uint128);
 
     function sharesToBalance(uint256 shares) public view returns (uint256) {
+        // WAD = 1e18
         return FixedPointMathLib.fullMulDiv(shares, balancePerShare(), 1e18); // floor
     }
 

--- a/src/ERC20Rebasing.sol
+++ b/src/ERC20Rebasing.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.23;
 import {ERC20} from "solady/src/tokens/ERC20.sol";
 import {mulDiv, mulDiv18} from "prb-math/Common.sol";
 import {NumberUtils} from "./common/NumberUtils.sol";
+import {FixedPointMathLib} from "solady/src/utils/FixedPointMathLib.sol";
 
 /// @notice Rebasing ERC20 token as an in-place upgrade to solady erc20
 /// @author Dinari (https://github.com/dinaricrypto/sbt-contracts/blob/main/src/dShare.sol)
@@ -27,7 +28,7 @@ abstract contract ERC20Rebasing is ERC20 {
     }
 
     function balanceToShares(uint256 balance) public view returns (uint256) {
-        return mulDiv(balance, _INITIAL_BALANCE_PER_SHARE, balancePerShare()); // floor
+        return FixedPointMathLib.mulDiv(balance, _INITIAL_BALANCE_PER_SHARE, balancePerShare()); // floor
     }
 
     /// ------------------ ERC20 ------------------

--- a/src/ERC20Rebasing.sol
+++ b/src/ERC20Rebasing.sol
@@ -36,6 +36,8 @@ abstract contract ERC20Rebasing is ERC20 {
         return sharesToBalance(super.totalSupply());
     }
 
+    /// @notice Returns the maximum supply of the token in balance.
+    /// @dev Useful for sanity checks before minting since the total supply of shares can overflow.
     function maxSupply() public view virtual returns (uint256) {
         // Reduced maxSupply of shares to prevent overflow in balanceToShares and other functions
         uint128 balancePerShare_ = balancePerShare();

--- a/src/ERC20Rebasing.sol
+++ b/src/ERC20Rebasing.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.23;
 
 import {ERC20} from "solady/src/tokens/ERC20.sol";
-import {mulDiv, mulDiv18} from "prb-math/Common.sol";
 import {NumberUtils} from "./common/NumberUtils.sol";
 import {FixedPointMathLib} from "solady/src/utils/FixedPointMathLib.sol";
 
@@ -24,11 +23,11 @@ abstract contract ERC20Rebasing is ERC20 {
     function balancePerShare() public view virtual returns (uint128);
 
     function sharesToBalance(uint256 shares) public view returns (uint256) {
-        return mulDiv18(shares, balancePerShare()); // floor
+        return FixedPointMathLib.fullMulDiv(shares, balancePerShare(), 1e18); // floor
     }
 
     function balanceToShares(uint256 balance) public view returns (uint256) {
-        return FixedPointMathLib.mulDiv(balance, _INITIAL_BALANCE_PER_SHARE, balancePerShare()); // floor
+        return FixedPointMathLib.fullMulDiv(balance, _INITIAL_BALANCE_PER_SHARE, balancePerShare()); // floor
     }
 
     /// ------------------ ERC20 ------------------
@@ -40,9 +39,9 @@ abstract contract ERC20Rebasing is ERC20 {
     function maxSupply() public view virtual returns (uint256) {
         uint128 balancePerShare_ = balancePerShare();
         if (balancePerShare_ < _INITIAL_BALANCE_PER_SHARE) {
-            return mulDiv18(type(uint256).max, balancePerShare_);
+            return FixedPointMathLib.mulWad(type(uint256).max, balancePerShare_);
         } else if (balancePerShare_ > _INITIAL_BALANCE_PER_SHARE) {
-            return mulDiv(type(uint256).max, _INITIAL_BALANCE_PER_SHARE, balancePerShare_);
+            return FixedPointMathLib.fullMulDiv(type(uint256).max, _INITIAL_BALANCE_PER_SHARE, balancePerShare_);
         }
         return type(uint256).max;
     }

--- a/src/ERC20Rebasing.sol
+++ b/src/ERC20Rebasing.sol
@@ -115,14 +115,8 @@ abstract contract ERC20Rebasing is ERC20 {
         }
         // Check overflow
         if (totalSharesAfter < totalSharesBefore) revert TotalSupplyOverflow();
-        // Check total supply limit
-        // Same as maxSupply logic, other balancePerShare scenario covered by the previous check
-        uint128 balancePerShare_ = balancePerShare();
-        if (
-            balancePerShare_ > _INITIAL_BALANCE_PER_SHARE
-                && sharesToBalance(totalSharesAfter)
-                    > FixedPointMathLib.fullMulDiv(type(uint256).max, _INITIAL_BALANCE_PER_SHARE, balancePerShare_)
-        ) revert TotalSupplyOverflow();
+        // Check total supply limit, can also revert with FullMulDivFailed in sharesToBalance
+        if (sharesToBalance(totalSharesAfter) > maxSupply()) revert TotalSupplyOverflow();
         /// @solidity memory-safe-assembly
         assembly {
             // Store the updated total supply.

--- a/src/ERC20Rebasing.sol
+++ b/src/ERC20Rebasing.sol
@@ -28,7 +28,7 @@ abstract contract ERC20Rebasing is ERC20 {
     }
 
     function balanceToShares(uint256 balance) public view returns (uint256) {
-        return FixedPointMathLib.fullMulDiv(balance, _INITIAL_BALANCE_PER_SHARE, balancePerShare()); // floor
+        return FixedPointMathLib.fullMulDiv(balance, _INITIAL_BALANCE_PER_SHARE, balancePerShare()); // ceil
     }
 
     /// ------------------ ERC20 ------------------

--- a/src/ERC20Rebasing.sol
+++ b/src/ERC20Rebasing.sol
@@ -113,7 +113,8 @@ abstract contract ERC20Rebasing is ERC20 {
         }
         // Check overflow
         if (totalSharesAfter < totalSharesBefore) revert TotalSupplyOverflow();
-        // Check total supply limit, same as maxSupply logic
+        // Check total supply limit
+        // Same as maxSupply logic, other balancePerShare scenario covered by the previous check
         uint128 balancePerShare_ = balancePerShare();
         if (
             balancePerShare_ > _INITIAL_BALANCE_PER_SHARE

--- a/src/common/NumberUtils.sol
+++ b/src/common/NumberUtils.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.23;
 
-import {FixedPointMathLib} from "solady/src/utils/FixedPointMathLib.sol";
-
 library NumberUtils {
     function addCheckOverflow(uint256 a, uint256 b) internal pure returns (bool) {
         uint256 c = 0;

--- a/src/common/NumberUtils.sol
+++ b/src/common/NumberUtils.sol
@@ -34,16 +34,4 @@ library NumberUtils {
         }
         return prod1 >= denominator;
     }
-
-    function mulDivUpCheckOverflow(uint256 a, uint256 b, uint256 denominator) internal pure returns (bool) {
-        if (mulDivCheckOverflow(a, b, denominator)) {
-            return true;
-        }
-        // brute force check
-        uint256 z = FixedPointMathLib.fullMulDiv(a, b, denominator);
-        assembly {
-            if mulmod(a, b, denominator) { z := add(z, 1) }
-        }
-        return z == 0;
-    }
 }

--- a/src/common/NumberUtils.sol
+++ b/src/common/NumberUtils.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.23;
 
+import {FixedPointMathLib} from "solady/src/utils/FixedPointMathLib.sol";
+
 library NumberUtils {
     function addCheckOverflow(uint256 a, uint256 b) internal pure returns (bool) {
         uint256 c = 0;
@@ -31,5 +33,17 @@ library NumberUtils {
             prod1 := sub(sub(mm, prod0), lt(mm, prod0))
         }
         return prod1 >= denominator;
+    }
+
+    function mulDivUpCheckOverflow(uint256 a, uint256 b, uint256 denominator) internal pure returns (bool) {
+        if (mulDivCheckOverflow(a, b, denominator)) {
+            return true;
+        }
+        // brute force check
+        uint256 z = FixedPointMathLib.fullMulDiv(a, b, denominator);
+        assembly {
+            if mulmod(a, b, denominator) { z := add(z, 1) }
+        }
+        return z == 0;
     }
 }


### PR DESCRIPTION
Addresses rounding from Pashov review

> Function burn() in UsdPlus contract, burns specified USD+ tokens from caller. It has been used during the withdraw process.
> 
>     /// @notice burn USD+ from msg.sender
>     function burn(uint256 value) external {
>         address from = _msgSender();
>         _useBurningLimits(from, value);
>         _burn(from, value);
>     }
> Because USD+ is a rebasing token to calculate the share burn amount code use _balancePerShare and divide the USD+ amount by this value.
> 
>     function balanceToShares(uint256 balance) public view returns (uint256) {
>         return mulDiv(balance, _INITIAL_BALANCE_PER_SHARE, balancePerShare()); // floor
>     }
> The issue is that by doing this the number of share amount would be round down and as result code would burn less than what caller specified. This would cause small profit for caller and in some circumstances malicious user can extract value because of this.
> 
> Round up in favor of contract when calculating the share amount in burn.

I (@jaketimothy ) added rounding change to transfer and burn.