### PR TITLE
Dshare 938 f 2024 7639 possibly invalid swap rate due to using unreliable market price

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@ out = "out"
 libs = ["node_modules", "lib"]
 solc_version = '0.8.25'
 evm_version = 'cancun'
-optimizer_runs = 2_000
+optimizer_runs = 1_500
 gas_price = 200_000_000
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/src/common/FeeLib.sol
+++ b/src/common/FeeLib.sol
@@ -5,9 +5,9 @@ import "prb-math/Common.sol" as PrbMath;
 
 library FeeLib {
     // 1_000_000 == 100%
-    uint24 private constant _ONEHUNDRED_PERCENT = 1_000_000;
+    uint24 internal constant _ONEHUNDRED_PERCENT = 1_000_000;
 
-    uint64 private constant _FLAT_FEE_DECIMALS = 8;
+    uint64 internal constant _FLAT_FEE_DECIMALS = 8;
 
     /// @dev Fee is too large
     error FeeTooLarge();

--- a/src/common/OracleLib.sol
+++ b/src/common/OracleLib.sol
@@ -20,4 +20,26 @@ library OracleLib {
         if (NumberUtils.mulDivCheckOverflow(paymentTokenQuantity, decimalMult, assetTokenQuantity)) return 0;
         return mulDiv(paymentTokenQuantity, decimalMult, assetTokenQuantity);
     }
+
+    function applyPriceAssetToPayment(uint256 assetTokenQuantity, uint256 price, uint8 paymentTokenDecimals)
+        internal
+        pure
+        returns (uint256)
+    {
+        // Adjusts the payment token decimals to match the asset token decimals (18) and removes 18 decimals from the result.
+        uint256 decimalMult = 10 ** (36 - paymentTokenDecimals);
+        if (NumberUtils.mulDivCheckOverflow(assetTokenQuantity, price, decimalMult)) return 0;
+        return mulDiv(assetTokenQuantity, price, decimalMult);
+    }
+
+    function applyPricePaymentToAsset(uint256 paymentTokenQuantity, uint256 price, uint8 paymentTokenDecimals)
+        internal
+        pure
+        returns (uint256)
+    {
+        // Adjusts the payment token decimals to match the asset token decimals (18) and removes 18 decimals from the result.
+        uint256 decimalMult = 10 ** (36 - paymentTokenDecimals);
+        if (NumberUtils.mulDivCheckOverflow(paymentTokenQuantity, decimalMult, price)) return 0;
+        return mulDiv(paymentTokenQuantity, decimalMult, price);
+    }
 }

--- a/src/plume-nest/DinariAdapterToken.sol
+++ b/src/plume-nest/DinariAdapterToken.sol
@@ -68,7 +68,7 @@ contract DinariAdapterToken is ComponentToken {
     error OrderDoesNotExist();
     error OrderStillActive();
     error InvalidPrice();
-    error StalePrice();
+    error StalePrice(uint64 blocktime, uint64 priceBlocktime);
     error AmountTooSmall();
 
     // Initializer
@@ -135,7 +135,9 @@ contract DinariAdapterToken is ComponentToken {
         DinariAdapterTokenStorage storage $ = _getDinariAdapterTokenStorage();
         IOrderProcessor.PricePoint memory pricePoint = orderContract.latestFillPrice($.dshareToken, paymentToken);
         if (pricePoint.price == 0) revert InvalidPrice();
-        if (pricePoint.blocktime + $.priceStaleDuration < block.timestamp) revert StalePrice();
+        if (block.timestamp - pricePoint.blocktime > $.priceStaleDuration) {
+            revert StalePrice(uint64(block.timestamp), pricePoint.blocktime);
+        }
         return pricePoint.price;
     }
 

--- a/test/DinariAdapterToken.t.sol
+++ b/test/DinariAdapterToken.t.sol
@@ -110,6 +110,8 @@ contract DinariAdapterTokenTest is Test {
         (uint256 flatFee,) = issuer.getStandardFees(false, address(usd));
         vm.assume(amount > flatFee);
 
+        uint64 priceTime = uint64(block.timestamp);
+
         // Place order to set price
         uint256 price = 10;
         IOrderProcessor.Order memory order = getDummyOrder(false);
@@ -122,7 +124,9 @@ contract DinariAdapterTokenTest is Test {
 
         vm.warp(block.timestamp + 1 days + 1);
 
-        vm.expectRevert(DinariAdapterToken.StalePrice.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(DinariAdapterToken.StalePrice.selector, uint64(block.timestamp), priceTime)
+        );
         adapterToken.convertToShares(amount);
     }
 
@@ -158,6 +162,8 @@ contract DinariAdapterTokenTest is Test {
         uint256 price = 10;
         vm.assume(!NumberUtils.mulCheckOverflow(shares, price));
 
+        uint64 priceTime = uint64(block.timestamp);
+
         // Place order to set price
         IOrderProcessor.Order memory order = getDummyOrder(true);
         vm.prank(admin);
@@ -174,7 +180,9 @@ contract DinariAdapterTokenTest is Test {
 
         vm.warp(block.timestamp + 1 days + 1);
 
-        vm.expectRevert(DinariAdapterToken.StalePrice.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(DinariAdapterToken.StalePrice.selector, uint64(block.timestamp), priceTime)
+        );
         adapterToken.convertToAssets(shares);
     }
 

--- a/test/DinariAdapterToken.t.sol
+++ b/test/DinariAdapterToken.t.sol
@@ -73,6 +73,90 @@ contract DinariAdapterTokenTest is Test {
         vm.stopPrank();
     }
 
+    function getDummyOrder(bool sell) internal view returns (IOrderProcessor.Order memory) {
+        return IOrderProcessor.Order({
+            requestTimestamp: uint64(block.timestamp),
+            recipient: user,
+            assetToken: address(token),
+            paymentToken: address(usd),
+            sell: sell,
+            orderType: IOrderProcessor.OrderType.MARKET,
+            assetTokenQuantity: sell ? 100 ether : 0,
+            paymentTokenQuantity: sell ? 0 : 100 * 10 ** usd.decimals(),
+            price: 0,
+            tif: IOrderProcessor.TIF.GTC
+        });
+    }
+
+    function testConvertToSharesTooSmallReverts(uint256 amount) public {
+        (uint256 flatFee,) = issuer.getStandardFees(false, address(usd));
+        vm.assume(amount <= flatFee);
+
+        // Fail if amount too small
+        vm.expectRevert(DinariAdapterToken.AmountTooSmall.selector);
+        adapterToken.convertToShares(0);
+    }
+
+    function testConvertToSharesNoPriceReverts(uint256 amount) public {
+        (uint256 flatFee,) = issuer.getStandardFees(false, address(usd));
+        vm.assume(amount > flatFee);
+
+        // Fail if no price
+        vm.expectRevert(DinariAdapterToken.InvalidPrice.selector);
+        adapterToken.convertToShares(amount);
+    }
+
+    function testConvertToShares(uint256 amount) public {
+        (uint256 flatFee,) = issuer.getStandardFees(false, address(usd));
+        vm.assume(amount > flatFee);
+
+        // Place order to set price
+        uint256 price = 10;
+        IOrderProcessor.Order memory order = getDummyOrder(false);
+        vm.prank(admin);
+        usd.mint(address(this), order.paymentTokenQuantity * 2);
+        usd.approve(address(issuer), order.paymentTokenQuantity * 2);
+        uint256 id = issuer.createOrderStandardFees(order);
+        vm.prank(operator);
+        issuer.fillOrder(order, order.paymentTokenQuantity, order.paymentTokenQuantity / price, 0);
+
+        // Convert to shares
+        uint256 shares = adapterToken.convertToShares(amount);
+        assertLe(shares, amount / price);
+    }
+
+    function testConvertToAssetsNoPriceReverts(uint256 shares) public {
+        vm.assume(shares > 0);
+
+        // Fail if no price
+        vm.expectRevert(DinariAdapterToken.InvalidPrice.selector);
+        adapterToken.convertToAssets(shares);
+    }
+
+    function testConvertToAssets(uint256 shares) public {
+        vm.assume(shares > 0);
+        uint256 price = 10;
+        vm.assume(!NumberUtils.mulCheckOverflow(shares, price));
+
+        // Place order to set price
+        IOrderProcessor.Order memory order = getDummyOrder(true);
+        vm.prank(admin);
+        token.mint(address(this), order.assetTokenQuantity);
+        token.approve(address(issuer), order.assetTokenQuantity);
+        uint256 id = issuer.createOrderStandardFees(order);
+        uint256 fillAmount = order.assetTokenQuantity * price;
+        vm.prank(admin);
+        usd.mint(operator, fillAmount);
+        vm.startPrank(operator);
+        usd.approve(address(issuer), fillAmount);
+        issuer.fillOrder(order, order.assetTokenQuantity, order.assetTokenQuantity * price, 0);
+        vm.stopPrank();
+
+        // Convert to assets
+        uint256 assets = adapterToken.convertToAssets(shares);
+        assertLe(assets, shares * price);
+    }
+
     function testRequestDepositFillProcessRequestRedeemFillProcess(uint128 amount) public {
         vm.assume(amount > 0.2e8);
 

--- a/test/OracleLib.t.sol
+++ b/test/OracleLib.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.22;
+
+import "forge-std/Test.sol";
+import {OracleLib} from "../src/common/OracleLib.sol";
+
+contract OracleLibTest is Test {
+    function testPairIndex() public {
+        bytes32 pairIndex = OracleLib.pairIndex(address(0x1), address(0x2));
+        assertEq(pairIndex, keccak256(abi.encodePacked(address(0x1), address(0x2))));
+    }
+
+    function testCalculatePriceOne(uint8 paymentTokenDecimals) public {
+        vm.assume(paymentTokenDecimals <= 18);
+        // 1:1 = 1e18
+        uint256 price = OracleLib.calculatePrice(1e18, 10 ** paymentTokenDecimals, paymentTokenDecimals);
+        assertEq(price, 1e18);
+    }
+
+    function testApplyPriceAssetToPaymentOne(uint8 paymentTokenDecimals) public {
+        vm.assume(paymentTokenDecimals <= 18);
+        uint256 payment = OracleLib.applyPriceAssetToPayment(1e18, 1e18, paymentTokenDecimals);
+        assertEq(payment, 10 ** paymentTokenDecimals);
+    }
+
+    function testApplyPricePaymentToAssetOne(uint8 paymentTokenDecimals) public {
+        vm.assume(paymentTokenDecimals <= 18);
+        uint256 asset = OracleLib.applyPricePaymentToAsset(10 ** paymentTokenDecimals, 1e18, paymentTokenDecimals);
+        assertEq(asset, 1e18);
+    }
+}


### PR DESCRIPTION
In reviewing the `convertToShares` and `convertToAssets` methods and adding testing to those view methods, additional math errors were corrected.

Fixes resulted in bytecode too large for our opt runs and additional changes were made to simplify the code.