### PR TITLE
feat: Pashov L-04 round up for mint check, down for transfers

### DIFF
--- a/src/ERC20Rebasing.sol
+++ b/src/ERC20Rebasing.sol
@@ -115,7 +115,7 @@ abstract contract ERC20Rebasing is ERC20 {
         }
         // Check overflow
         if (totalSharesAfter < totalSharesBefore) revert TotalSupplyOverflow();
-        // Check total supply limit, can also revert with FullMulDivFailed in sharesToBalance
+        // Check total supply limit, can also revert with FullMulDivFailed in fullMulDivUp
         // Round up for total supply limit check
         if (
             FixedPointMathLib.fullMulDivUp(totalSharesAfter, balancePerShare(), _INITIAL_BALANCE_PER_SHARE)

--- a/src/ERC20Rebasing.sol
+++ b/src/ERC20Rebasing.sol
@@ -27,7 +27,7 @@ abstract contract ERC20Rebasing is ERC20 {
     }
 
     function balanceToShares(uint256 balance) public view returns (uint256) {
-        return FixedPointMathLib.fullMulDivUp(balance, _INITIAL_BALANCE_PER_SHARE, balancePerShare()); // ceil
+        return FixedPointMathLib.fullMulDiv(balance, _INITIAL_BALANCE_PER_SHARE, balancePerShare()); // floor
     }
 
     /// ------------------ ERC20 ------------------
@@ -107,7 +107,7 @@ abstract contract ERC20Rebasing is ERC20 {
         _beforeTokenTransfer(address(0), to, amount);
         uint256 totalSharesBefore = super.totalSupply();
         // Floor the shares to mint
-        uint256 shares = FixedPointMathLib.fullMulDiv(amount, _INITIAL_BALANCE_PER_SHARE, balancePerShare());
+        uint256 shares = balanceToShares(amount);
         // Check the total supply limit for shares
         uint256 totalSharesAfter = 0;
         unchecked {
@@ -116,7 +116,11 @@ abstract contract ERC20Rebasing is ERC20 {
         // Check overflow
         if (totalSharesAfter < totalSharesBefore) revert TotalSupplyOverflow();
         // Check total supply limit, can also revert with FullMulDivFailed in sharesToBalance
-        if (sharesToBalance(totalSharesAfter) > maxSupply()) revert TotalSupplyOverflow();
+        // Round up for total supply limit check
+        if (
+            FixedPointMathLib.fullMulDivUp(totalSharesAfter, balancePerShare(), _INITIAL_BALANCE_PER_SHARE)
+                > maxSupply()
+        ) revert TotalSupplyOverflow();
         /// @solidity memory-safe-assembly
         assembly {
             // Store the updated total supply.
@@ -137,7 +141,8 @@ abstract contract ERC20Rebasing is ERC20 {
     // Convert to shares
     function _burn(address from, uint256 amount) internal virtual override {
         _beforeTokenTransfer(from, address(0), amount);
-        uint256 shares = balanceToShares(amount);
+        // Round up the shares to burn in favor of the contract
+        uint256 shares = FixedPointMathLib.fullMulDivUp(amount, _INITIAL_BALANCE_PER_SHARE, balancePerShare());
         /// @solidity memory-safe-assembly
         assembly {
             // Compute the balance slot and load its value.

--- a/test/dShare.t.sol
+++ b/test/dShare.t.sol
@@ -275,7 +275,8 @@ contract DShareTest is Test {
         assertTrue(token.transfer(user, senderBalance));
         assertLe(token.totalSupply(), balance);
 
-        assertEq(token.balanceOf(address(this)), 0);
+        // Can collect dust
+        // assertEq(token.balanceOf(address(this)), 0);
         assertLe(token.balanceOf(user), balance);
     }
 


### PR DESCRIPTION
Addresses feedback from Pashov

> _transfer() -> balanceToShares(): Changed to round up
> I believe the transfer operation should round down when converting the transfered balance to shares, as rounding up will add more shares to the recipient's balance than what was actually transferred.
> 
> _mint() -> additional checks: sharesToBalance(totalSharesAfter) > maxSupply(): Rounded down
> I believe this additional check should round up, as rounding down can underestimate the precision loss and cause the value to exceed maxSupply().