### PR TITLE
[DSHARE-1297] Batch restrict for sbt-contract

### DIFF
--- a/src/TransferRestrictor.sol
+++ b/src/TransferRestrictor.sol
@@ -44,6 +44,16 @@ contract TransferRestrictor is AccessControlDefaultAdminRules, ITransferRestrict
         emit Restricted(account);
     }
 
+    /// @notice Restrict multiple accounts from sending or receiving tokens
+    /// @dev Does not check if `account` is restricted
+    /// Can only be called by `RESTRICTOR_ROLE`
+    function restrict(address[] memory accounts) external onlyRole(RESTRICTOR_ROLE) {
+        for (uint256 i = 0; i < accounts.length; i++) {
+            isBlacklisted[accounts[i]] = true;
+            emit Restricted(accounts[i]);
+        }
+    }
+
     /// @notice Unrestrict `account` from sending or receiving tokens
     /// @dev Does not check if `account` is restricted
     /// Can only be called by `RESTRICTOR_ROLE`

--- a/test/TransferRestrictor.t.sol
+++ b/test/TransferRestrictor.t.sol
@@ -52,5 +52,21 @@ contract TransferRestrictorTest is Test {
         restrictor.requireNotRestricted(account, address(0));
         restrictor.requireNotRestricted(address(0), account);
         vm.stopPrank();
+
+        address[] memory accounts = generateTestAddresses(100);
+        vm.prank(restrictor_role);
+        restrictor.restrict(accounts);
+        for (uint256 i = 0; i < accounts.length; i++) {
+            assertEq(restrictor.isBlacklisted(accounts[i]), true);
+        }
+    }
+
+
+    function generateTestAddresses(uint256 count) internal pure returns (address[] memory) {
+        address[] memory addresses = new address[](count);
+        for (uint256 i = 0; i < count; i++) {
+            addresses[i] = address(uint160(i + 100)); // Unique deterministic addresses
+        }
+        return addresses;
     }
 }


### PR DESCRIPTION
this [PR ](https://dinari.atlassian.net/jira/software/projects/DSHARE/boards/2?assignee=712020%3Aa20e54a0-5e4c-4203-9d5b-a3911c614d59&selectedIssue=DSHARE-1297)allows the TransferRestrictor contract by adding support for restricting multiple addresses in a single transaction.