### PR TITLE
[DSHARE-2828] Add new dividend distribution method mintDistribution and mintWithholding

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -8,4 +8,14 @@ optimizer_runs = 800
 gas_price = 200_000_000
 fs_permissions = [{ access = "read-write", path = "./"}]
 
+[profile.ci]
+src = "src"
+out = "out"
+libs = ["node_modules", "lib"]
+solc_version = '0.8.25'
+evm_version = 'cancun'
+optimizer_runs = 800
+gas_price = 200_000_000
+fs_permissions = [{ access = "read-write", path = "./"}]
+
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/src/dividend/DividendDistribution.sol
+++ b/src/dividend/DividendDistribution.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.25;
 import {ControlledUpgradeable} from "../deployment/ControlledUpgradeable.sol";
 import {SafeERC20, IERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IDividendDistributor} from "./IDividendDistributor.sol";
+import {IDShare} from "../IDShare.sol";
 
 /// @notice Distributes tokens to users over time.
 /// @dev This contract allows a DISTRIBUTOR_ROLE to create a distribution of tokens to users.
@@ -35,11 +36,23 @@ contract DividendDistribution is ControlledUpgradeable, IDividendDistributor {
 
     event DistributionReclaimed(uint256 indexed distributionId, uint256 totalReclaimed);
 
+    event DistributionMinted(
+        bytes32 indexed distributionFillId, address indexed recipient, address indexed token, uint256 amount
+    );
+
+    event WithholdingMinted(
+        bytes32 indexed distributionWithholdingId, address indexed recipient, address indexed token, uint256 amount
+    );
+
     // Custom errors
     error EndTimeBeforeMin(); // Error thrown when endtime is prior to minDistributionTime from now.
     error DistributionRunning(); // Error thrown when trying to reclaim tokens from an distribution that is still running.
     error DistributionEnded(); // Error thrown when trying to claim tokens from an distribution that has ended.
     error NotReclaimable(); // Error thrown when the distribution has already been reclaimed or does not exist.
+    error DistributionAlreadyFilled(bytes32 distributionFillId);
+    error WithholdingAlreadyFilled(bytes32 distributionWithholdingId);
+    error ZeroAddress();
+    error ZeroAmount();
 
     /// ------------------ Constants ------------------ ///
 
@@ -57,13 +70,19 @@ contract DividendDistribution is ControlledUpgradeable, IDividendDistributor {
     /// @notice The minimum time that must pass between the creation of a distribution and its end time.
     uint64 public minDistributionTime = 1 days;
 
+    /// @notice Tracks processed distribution fill IDs for idempotency
+    mapping(bytes32 => bool) public distributionFilled;
+
+    /// @notice Tracks processed withholding IDs for idempotency
+    mapping(bytes32 => bool) public withholdingFilled;
+
     /// ------------------- Version ------------------- ///
     function version() public view override returns (uint8) {
-        return 1;
+        return 2;
     }
 
     function publicVersion() public view override returns (string memory) {
-        return "1.0.0";
+        return "2.0.0";
     }
 
     /// ------------------- Initialization ------------------- ///
@@ -135,5 +154,49 @@ contract DividendDistribution is ControlledUpgradeable, IDividendDistributor {
 
         // Transfer the unclaimed tokens back to the distributor
         IERC20(token).safeTransfer(msg.sender, totalReclaimed);
+    }
+
+    /// ------------------- Direct Minting ------------------- ///
+
+    /// @notice Mint tokens directly to recipient for dividend distribution
+    /// @param token Token address to mint (vUSD or DShare)
+    /// @param amount Amount to mint
+    /// @param recipient Address receiving tokens
+    /// @param distributionFillId Unique UUID for idempotency
+    function mintDistribution(address token, uint256 amount, address recipient, bytes32 distributionFillId)
+        external
+        onlyRole(DISTRIBUTOR_ROLE)
+    {
+        if (distributionFilled[distributionFillId]) revert DistributionAlreadyFilled(distributionFillId);
+        if (token == address(0)) revert ZeroAddress();
+        if (recipient == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+
+        distributionFilled[distributionFillId] = true;
+
+        emit DistributionMinted(distributionFillId, recipient, token, amount);
+
+        IDShare(token).mint(recipient, amount);
+    }
+
+    /// @notice Mint tokens to recipient for tax withholding
+    /// @param token Token address to mint (vUSD)
+    /// @param amount Amount to mint
+    /// @param recipient Withholder address
+    /// @param distributionWithholdingId Unique UUID for idempotency
+    function mintWithholding(address token, uint256 amount, address recipient, bytes32 distributionWithholdingId)
+        external
+        onlyRole(DISTRIBUTOR_ROLE)
+    {
+        if (withholdingFilled[distributionWithholdingId]) revert WithholdingAlreadyFilled(distributionWithholdingId);
+        if (token == address(0)) revert ZeroAddress();
+        if (recipient == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+
+        withholdingFilled[distributionWithholdingId] = true;
+
+        emit WithholdingMinted(distributionWithholdingId, recipient, token, amount);
+
+        IDShare(token).mint(recipient, amount);
     }
 }

--- a/src/dividend/DividendDistribution.sol
+++ b/src/dividend/DividendDistribution.sol
@@ -36,21 +36,29 @@ contract DividendDistribution is ControlledUpgradeable, IDividendDistributor {
 
     event DistributionReclaimed(uint256 indexed distributionId, uint256 totalReclaimed);
 
-    event DistributionMinted(
-        bytes32 indexed distributionFillId, address indexed recipient, address indexed token, uint256 amount
+    event DividendMinted(
+        bytes32 indexed brokerageDividendId, address indexed target, address indexed token, uint256 amount
     );
 
-    event WithholdingMinted(
-        bytes32 indexed distributionWithholdingId, address indexed recipient, address indexed token, uint256 amount
+    event DistributionSent(
+        bytes32 indexed distributionId, address indexed recipient, address indexed token, uint256 amount
     );
+
+    event WithholdingSent(
+        bytes32 indexed withholdingId, address indexed recipient, address indexed token, uint256 amount
+    );
+
+    event FeeSent(bytes32 indexed feeId, address indexed recipient, address indexed token, uint256 amount);
 
     // Custom errors
     error EndTimeBeforeMin(); // Error thrown when endtime is prior to minDistributionTime from now.
     error DistributionRunning(); // Error thrown when trying to reclaim tokens from an distribution that is still running.
     error DistributionEnded(); // Error thrown when trying to claim tokens from an distribution that has ended.
     error NotReclaimable(); // Error thrown when the distribution has already been reclaimed or does not exist.
-    error DistributionAlreadyFilled(bytes32 distributionFillId);
-    error WithholdingAlreadyFilled(bytes32 distributionWithholdingId);
+    error DividendAlreadyMinted(bytes32 brokerageDividendId);
+    error DistributionAlreadySent(bytes32 distributionId);
+    error WithholdingAlreadySent(bytes32 withholdingId);
+    error FeeAlreadySent(bytes32 feeId);
     error ZeroAddress();
     error ZeroAmount();
 
@@ -70,11 +78,17 @@ contract DividendDistribution is ControlledUpgradeable, IDividendDistributor {
     /// @notice The minimum time that must pass between the creation of a distribution and its end time.
     uint64 public minDistributionTime = 1 days;
 
-    /// @notice Tracks processed distribution fill IDs for idempotency
-    mapping(bytes32 => bool) public distributionFilled;
+    /// @notice Tracks processed brokerage dividend IDs for idempotency
+    mapping(bytes32 => bool) public dividendMinted;
+
+    /// @notice Tracks processed distribution IDs for idempotency
+    mapping(bytes32 => bool) public distributionSent;
 
     /// @notice Tracks processed withholding IDs for idempotency
-    mapping(bytes32 => bool) public withholdingFilled;
+    mapping(bytes32 => bool) public withholdingSent;
+
+    /// @notice Tracks processed fee IDs for idempotency
+    mapping(bytes32 => bool) public feeSent;
 
     /// ------------------- Version ------------------- ///
     function version() public view override returns (uint8) {
@@ -156,47 +170,91 @@ contract DividendDistribution is ControlledUpgradeable, IDividendDistributor {
         IERC20(token).safeTransfer(msg.sender, totalReclaimed);
     }
 
-    /// ------------------- Direct Minting ------------------- ///
+    /// ------------------- Dividend Minting ------------------- ///
 
-    /// @notice Mint tokens directly to recipient for dividend distribution
+    /// @notice Mint tokens for a brokerage dividend to a target address
     /// @param token Token address to mint (vUSD or DShare)
     /// @param amount Amount to mint
-    /// @param recipient Address receiving tokens
-    /// @param distributionFillId Unique UUID for idempotency
-    function mintDistribution(address token, uint256 amount, address recipient, bytes32 distributionFillId)
+    /// @param target Address receiving minted tokens (this contract for omnibus, or user wallet for individual brokerage)
+    /// @param brokerageDividendId Unique brokerage dividend ID for idempotency
+    function mintDividend(address token, uint256 amount, address target, bytes32 brokerageDividendId)
         external
         onlyRole(DISTRIBUTOR_ROLE)
     {
-        if (distributionFilled[distributionFillId]) revert DistributionAlreadyFilled(distributionFillId);
+        if (dividendMinted[brokerageDividendId]) revert DividendAlreadyMinted(brokerageDividendId);
         if (token == address(0)) revert ZeroAddress();
-        if (recipient == address(0)) revert ZeroAddress();
+        if (target == address(0)) revert ZeroAddress();
         if (amount == 0) revert ZeroAmount();
 
-        distributionFilled[distributionFillId] = true;
+        dividendMinted[brokerageDividendId] = true;
 
-        emit DistributionMinted(distributionFillId, recipient, token, amount);
+        emit DividendMinted(brokerageDividendId, target, token, amount);
 
-        IDShare(token).mint(recipient, amount);
+        IDShare(token).mint(target, amount);
     }
 
-    /// @notice Mint tokens to recipient for tax withholding
-    /// @param token Token address to mint (vUSD)
-    /// @param amount Amount to mint
-    /// @param recipient Withholder address
-    /// @param distributionWithholdingId Unique UUID for idempotency
-    function mintWithholding(address token, uint256 amount, address recipient, bytes32 distributionWithholdingId)
+    /// ------------------- Distribution Sends ------------------- ///
+
+    /// @notice Send distribution tokens to a recipient from contract balance
+    /// @param token Token address (vUSD or DShare)
+    /// @param amount Amount to send
+    /// @param recipient Address receiving tokens
+    /// @param distributionId Unique distribution ID for idempotency
+    function sendDistribution(address token, uint256 amount, address recipient, bytes32 distributionId)
         external
         onlyRole(DISTRIBUTOR_ROLE)
     {
-        if (withholdingFilled[distributionWithholdingId]) revert WithholdingAlreadyFilled(distributionWithholdingId);
+        if (distributionSent[distributionId]) revert DistributionAlreadySent(distributionId);
         if (token == address(0)) revert ZeroAddress();
         if (recipient == address(0)) revert ZeroAddress();
         if (amount == 0) revert ZeroAmount();
 
-        withholdingFilled[distributionWithholdingId] = true;
+        distributionSent[distributionId] = true;
 
-        emit WithholdingMinted(distributionWithholdingId, recipient, token, amount);
+        emit DistributionSent(distributionId, recipient, token, amount);
 
-        IDShare(token).mint(recipient, amount);
+        IERC20(token).safeTransfer(recipient, amount);
+    }
+
+    /// @notice Send withholding tokens to a recipient from contract balance
+    /// @param token Token address (vUSD)
+    /// @param amount Amount to send
+    /// @param recipient Withholder address
+    /// @param withholdingId Unique withholding ID for idempotency
+    function sendWithholding(address token, uint256 amount, address recipient, bytes32 withholdingId)
+        external
+        onlyRole(DISTRIBUTOR_ROLE)
+    {
+        if (withholdingSent[withholdingId]) revert WithholdingAlreadySent(withholdingId);
+        if (token == address(0)) revert ZeroAddress();
+        if (recipient == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+
+        withholdingSent[withholdingId] = true;
+
+        emit WithholdingSent(withholdingId, recipient, token, amount);
+
+        IERC20(token).safeTransfer(recipient, amount);
+    }
+
+    /// @notice Send fee tokens to a revenue vault from contract balance
+    /// @param token Token address (vUSD)
+    /// @param amount Fee amount to send
+    /// @param recipient Revenue vault address
+    /// @param feeId Unique fee ID for idempotency
+    function sendFee(address token, uint256 amount, address recipient, bytes32 feeId)
+        external
+        onlyRole(DISTRIBUTOR_ROLE)
+    {
+        if (feeSent[feeId]) revert FeeAlreadySent(feeId);
+        if (token == address(0)) revert ZeroAddress();
+        if (recipient == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+
+        feeSent[feeId] = true;
+
+        emit FeeSent(feeId, recipient, token, amount);
+
+        IERC20(token).safeTransfer(recipient, amount);
     }
 }

--- a/src/dividend/IDividendDistributor.sol
+++ b/src/dividend/IDividendDistributor.sol
@@ -35,21 +35,38 @@ interface IDividendDistributor {
     function reclaimDistribution(uint256 _distributionId) external;
 
     /**
-     * @notice Mint tokens directly to recipient for dividend distribution
+     * @notice Mint tokens for a brokerage dividend to a target address
      * @param token Token address to mint (vUSD or DShare)
      * @param amount Amount to mint
-     * @param recipient Address receiving tokens
-     * @param distributionFillId Unique UUID for idempotency
+     * @param target Address receiving minted tokens (contract for omnibus, or user wallet for individual brokerage)
+     * @param brokerageDividendId Unique brokerage dividend ID for idempotency
      */
-    function mintDistribution(address token, uint256 amount, address recipient, bytes32 distributionFillId) external;
+    function mintDividend(address token, uint256 amount, address target, bytes32 brokerageDividendId) external;
 
     /**
-     * @notice Mint tokens to recipient for tax withholding
-     * @param token Token address to mint (vUSD)
-     * @param amount Amount to mint
-     * @param recipient Withholder address
-     * @param distributionWithholdingId Unique UUID for idempotency
+     * @notice Send distribution tokens to a recipient from contract balance
+     * @param token Token address (vUSD or DShare)
+     * @param amount Amount to send
+     * @param recipient Address receiving tokens
+     * @param distributionId Unique distribution ID for idempotency
      */
-    function mintWithholding(address token, uint256 amount, address recipient, bytes32 distributionWithholdingId)
-        external;
+    function sendDistribution(address token, uint256 amount, address recipient, bytes32 distributionId) external;
+
+    /**
+     * @notice Send withholding tokens to a recipient from contract balance
+     * @param token Token address (vUSD)
+     * @param amount Amount to send
+     * @param recipient Withholder address
+     * @param withholdingId Unique withholding ID for idempotency
+     */
+    function sendWithholding(address token, uint256 amount, address recipient, bytes32 withholdingId) external;
+
+    /**
+     * @notice Send fee tokens to a revenue vault from contract balance
+     * @param token Token address (vUSD)
+     * @param amount Fee amount to send
+     * @param recipient Revenue vault address
+     * @param feeId Unique fee ID for idempotency
+     */
+    function sendFee(address token, uint256 amount, address recipient, bytes32 feeId) external;
 }

--- a/src/dividend/IDividendDistributor.sol
+++ b/src/dividend/IDividendDistributor.sol
@@ -33,4 +33,23 @@ interface IDividendDistributor {
      * @dev Can only be called by the distributor after the claim window has passed.
      */
     function reclaimDistribution(uint256 _distributionId) external;
+
+    /**
+     * @notice Mint tokens directly to recipient for dividend distribution
+     * @param token Token address to mint (vUSD or DShare)
+     * @param amount Amount to mint
+     * @param recipient Address receiving tokens
+     * @param distributionFillId Unique UUID for idempotency
+     */
+    function mintDistribution(address token, uint256 amount, address recipient, bytes32 distributionFillId) external;
+
+    /**
+     * @notice Mint tokens to recipient for tax withholding
+     * @param token Token address to mint (vUSD)
+     * @param amount Amount to mint
+     * @param recipient Withholder address
+     * @param distributionWithholdingId Unique UUID for idempotency
+     */
+    function mintWithholding(address token, uint256 amount, address recipient, bytes32 distributionWithholdingId)
+        external;
 }

--- a/test/DividendDistribution.t.sol
+++ b/test/DividendDistribution.t.sol
@@ -32,6 +32,7 @@ contract DividendDistributionTest is Test {
     address public admin;
     address public distributor = address(4);
     address public withholder = address(5);
+    address public revenueVault = address(6);
 
     struct HashAndDataTuple {
         uint256 originalData;
@@ -44,12 +45,16 @@ contract DividendDistributionTest is Test {
         uint256 indexed distributionId, uint256 totalDistribution, uint256 startDate, uint256 endDate
     );
     event DistributionReclaimed(uint256 indexed distributionId, uint256 totalReclaimed);
-    event DistributionMinted(
-        bytes32 indexed distributionFillId, address indexed recipient, address indexed token, uint256 amount
+    event DividendMinted(
+        bytes32 indexed brokerageDividendId, address indexed target, address indexed token, uint256 amount
     );
-    event WithholdingMinted(
-        bytes32 indexed distributionWithholdingId, address indexed recipient, address indexed token, uint256 amount
+    event DistributionSent(
+        bytes32 indexed distributionId, address indexed recipient, address indexed token, uint256 amount
     );
+    event WithholdingSent(
+        bytes32 indexed withholdingId, address indexed recipient, address indexed token, uint256 amount
+    );
+    event FeeSent(bytes32 indexed feeId, address indexed recipient, address indexed token, uint256 amount);
 
     function setUp() public {
         userPrivateKey = 0x01;
@@ -198,98 +203,52 @@ contract DividendDistributionTest is Test {
         assertEq(IERC20(address(token)).balanceOf(distributor), totalDistribution);
     }
 
-    // ------------------- mintDistribution Tests ------------------- //
+    // ------------------- mintDividend Tests ------------------- //
 
-    function testMintDistribution() public {
-        bytes32 fillId = keccak256("unique-fill-id-1");
+    function testMintDividendToWallet() public {
+        bytes32 brokerageDividendId = keccak256("brokerage-dividend-1");
         uint256 amount = 1000e18;
 
         vm.expectEmit(true, true, true, true);
-        emit DistributionMinted(fillId, user, address(dshareToken), amount);
+        emit DividendMinted(brokerageDividendId, user, address(dshareToken), amount);
 
         vm.prank(distributor);
-        distribution.mintDistribution(address(dshareToken), amount, user, fillId);
+        distribution.mintDividend(address(dshareToken), amount, user, brokerageDividendId);
 
         assertEq(dshareToken.balanceOf(user), amount);
-        assertTrue(distribution.distributionFilled(fillId));
+        assertTrue(distribution.dividendMinted(brokerageDividendId));
     }
 
-    function testMintDistributionIdempotency() public {
-        bytes32 fillId = keccak256("unique-fill-id-2");
-        uint256 amount = 1000e18;
-
-        vm.prank(distributor);
-        distribution.mintDistribution(address(dshareToken), amount, user, fillId);
-
-        vm.expectRevert(abi.encodeWithSelector(DividendDistribution.DistributionAlreadyFilled.selector, fillId));
-        vm.prank(distributor);
-        distribution.mintDistribution(address(dshareToken), amount, user, fillId);
-    }
-
-    function testMintDistributionOnlyDistributor() public {
-        bytes32 fillId = keccak256("unique-fill-id-3");
-        uint256 amount = 1000e18;
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector, user, distribution.DISTRIBUTOR_ROLE()
-            )
-        );
-        vm.prank(user);
-        distribution.mintDistribution(address(dshareToken), amount, user, fillId);
-    }
-
-    function testMintDistributionZeroChecks() public {
-        bytes32 fillId = keccak256("unique-fill-id-4");
-        uint256 amount = 1000e18;
-
-        // Test zero token address
-        vm.expectRevert(DividendDistribution.ZeroAddress.selector);
-        vm.prank(distributor);
-        distribution.mintDistribution(address(0), amount, user, fillId);
-
-        // Test zero recipient address
-        vm.expectRevert(DividendDistribution.ZeroAddress.selector);
-        vm.prank(distributor);
-        distribution.mintDistribution(address(dshareToken), amount, address(0), fillId);
-
-        // Test zero amount
-        vm.expectRevert(DividendDistribution.ZeroAmount.selector);
-        vm.prank(distributor);
-        distribution.mintDistribution(address(dshareToken), 0, user, fillId);
-    }
-
-    // ------------------- mintWithholding Tests ------------------- //
-
-    function testMintWithholding() public {
-        bytes32 withholdingId = keccak256("unique-withholding-id-1");
-        uint256 amount = 500e18;
+    function testMintDividendToContract() public {
+        bytes32 brokerageDividendId = keccak256("brokerage-dividend-2");
+        uint256 amount = 5000e18;
 
         vm.expectEmit(true, true, true, true);
-        emit WithholdingMinted(withholdingId, withholder, address(dshareToken), amount);
+        emit DividendMinted(brokerageDividendId, address(distribution), address(dshareToken), amount);
 
         vm.prank(distributor);
-        distribution.mintWithholding(address(dshareToken), amount, withholder, withholdingId);
+        distribution.mintDividend(address(dshareToken), amount, address(distribution), brokerageDividendId);
 
-        assertEq(dshareToken.balanceOf(withholder), amount);
-        assertTrue(distribution.withholdingFilled(withholdingId));
+        assertEq(dshareToken.balanceOf(address(distribution)), amount);
     }
 
-    function testMintWithholdingIdempotency() public {
-        bytes32 withholdingId = keccak256("unique-withholding-id-2");
-        uint256 amount = 500e18;
+    function testMintDividendIdempotency() public {
+        bytes32 brokerageDividendId = keccak256("brokerage-dividend-3");
+        uint256 amount = 1000e18;
 
         vm.prank(distributor);
-        distribution.mintWithholding(address(dshareToken), amount, withholder, withholdingId);
+        distribution.mintDividend(address(dshareToken), amount, user, brokerageDividendId);
 
-        vm.expectRevert(abi.encodeWithSelector(DividendDistribution.WithholdingAlreadyFilled.selector, withholdingId));
+        vm.expectRevert(
+            abi.encodeWithSelector(DividendDistribution.DividendAlreadyMinted.selector, brokerageDividendId)
+        );
         vm.prank(distributor);
-        distribution.mintWithholding(address(dshareToken), amount, withholder, withholdingId);
+        distribution.mintDividend(address(dshareToken), amount, user, brokerageDividendId);
     }
 
-    function testMintWithholdingOnlyDistributor() public {
-        bytes32 withholdingId = keccak256("unique-withholding-id-3");
-        uint256 amount = 500e18;
+    function testMintDividendOnlyDistributor() public {
+        bytes32 brokerageDividendId = keccak256("brokerage-dividend-4");
+        uint256 amount = 1000e18;
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -297,26 +256,267 @@ contract DividendDistributionTest is Test {
             )
         );
         vm.prank(user);
-        distribution.mintWithholding(address(dshareToken), amount, withholder, withholdingId);
+        distribution.mintDividend(address(dshareToken), amount, user, brokerageDividendId);
     }
 
-    function testMintWithholdingZeroChecks() public {
-        bytes32 withholdingId = keccak256("unique-withholding-id-4");
-        uint256 amount = 500e18;
+    function testMintDividendZeroChecks() public {
+        bytes32 brokerageDividendId = keccak256("brokerage-dividend-5");
+        uint256 amount = 1000e18;
 
-        // Test zero token address
         vm.expectRevert(DividendDistribution.ZeroAddress.selector);
         vm.prank(distributor);
-        distribution.mintWithholding(address(0), amount, withholder, withholdingId);
+        distribution.mintDividend(address(0), amount, user, brokerageDividendId);
 
-        // Test zero recipient address
         vm.expectRevert(DividendDistribution.ZeroAddress.selector);
         vm.prank(distributor);
-        distribution.mintWithholding(address(dshareToken), amount, address(0), withholdingId);
+        distribution.mintDividend(address(dshareToken), amount, address(0), brokerageDividendId);
 
-        // Test zero amount
         vm.expectRevert(DividendDistribution.ZeroAmount.selector);
         vm.prank(distributor);
-        distribution.mintWithholding(address(dshareToken), 0, withholder, withholdingId);
+        distribution.mintDividend(address(dshareToken), 0, user, brokerageDividendId);
+    }
+
+    // ------------------- sendDistribution Tests ------------------- //
+
+    function testSendDistribution() public {
+        // First mint to contract
+        bytes32 brokerageDividendId = keccak256("brokerage-dividend-send-1");
+        uint256 totalAmount = 5000e18;
+        vm.prank(distributor);
+        distribution.mintDividend(address(dshareToken), totalAmount, address(distribution), brokerageDividendId);
+
+        // Send distribution to user
+        bytes32 distributionId = keccak256("distribution-1");
+        uint256 userAmount = 1000e18;
+
+        vm.expectEmit(true, true, true, true);
+        emit DistributionSent(distributionId, user, address(dshareToken), userAmount);
+
+        vm.prank(distributor);
+        distribution.sendDistribution(address(dshareToken), userAmount, user, distributionId);
+
+        assertEq(dshareToken.balanceOf(user), userAmount);
+        assertEq(dshareToken.balanceOf(address(distribution)), totalAmount - userAmount);
+        assertTrue(distribution.distributionSent(distributionId));
+    }
+
+    function testSendDistributionIdempotency() public {
+        bytes32 brokerageDividendId = keccak256("brokerage-dividend-send-2");
+        vm.prank(distributor);
+        distribution.mintDividend(address(dshareToken), 5000e18, address(distribution), brokerageDividendId);
+
+        bytes32 distributionId = keccak256("distribution-2");
+        uint256 amount = 1000e18;
+
+        vm.prank(distributor);
+        distribution.sendDistribution(address(dshareToken), amount, user, distributionId);
+
+        vm.expectRevert(abi.encodeWithSelector(DividendDistribution.DistributionAlreadySent.selector, distributionId));
+        vm.prank(distributor);
+        distribution.sendDistribution(address(dshareToken), amount, user, distributionId);
+    }
+
+    function testSendDistributionOnlyDistributor() public {
+        bytes32 distributionId = keccak256("distribution-3");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, user, distribution.DISTRIBUTOR_ROLE()
+            )
+        );
+        vm.prank(user);
+        distribution.sendDistribution(address(dshareToken), 1000e18, user, distributionId);
+    }
+
+    function testSendDistributionZeroChecks() public {
+        bytes32 distributionId = keccak256("distribution-4");
+        uint256 amount = 1000e18;
+
+        vm.expectRevert(DividendDistribution.ZeroAddress.selector);
+        vm.prank(distributor);
+        distribution.sendDistribution(address(0), amount, user, distributionId);
+
+        vm.expectRevert(DividendDistribution.ZeroAddress.selector);
+        vm.prank(distributor);
+        distribution.sendDistribution(address(dshareToken), amount, address(0), distributionId);
+
+        vm.expectRevert(DividendDistribution.ZeroAmount.selector);
+        vm.prank(distributor);
+        distribution.sendDistribution(address(dshareToken), 0, user, distributionId);
+    }
+
+    // ------------------- sendWithholding Tests ------------------- //
+
+    function testSendWithholding() public {
+        bytes32 brokerageDividendId = keccak256("brokerage-dividend-wh-1");
+        uint256 totalAmount = 5000e18;
+        vm.prank(distributor);
+        distribution.mintDividend(address(dshareToken), totalAmount, address(distribution), brokerageDividendId);
+
+        bytes32 withholdingId = keccak256("withholding-1");
+        uint256 withholdingAmount = 200e18;
+
+        vm.expectEmit(true, true, true, true);
+        emit WithholdingSent(withholdingId, withholder, address(dshareToken), withholdingAmount);
+
+        vm.prank(distributor);
+        distribution.sendWithholding(address(dshareToken), withholdingAmount, withholder, withholdingId);
+
+        assertEq(dshareToken.balanceOf(withholder), withholdingAmount);
+        assertTrue(distribution.withholdingSent(withholdingId));
+    }
+
+    function testSendWithholdingIdempotency() public {
+        bytes32 brokerageDividendId = keccak256("brokerage-dividend-wh-2");
+        vm.prank(distributor);
+        distribution.mintDividend(address(dshareToken), 5000e18, address(distribution), brokerageDividendId);
+
+        bytes32 withholdingId = keccak256("withholding-2");
+        uint256 amount = 200e18;
+
+        vm.prank(distributor);
+        distribution.sendWithholding(address(dshareToken), amount, withholder, withholdingId);
+
+        vm.expectRevert(abi.encodeWithSelector(DividendDistribution.WithholdingAlreadySent.selector, withholdingId));
+        vm.prank(distributor);
+        distribution.sendWithholding(address(dshareToken), amount, withholder, withholdingId);
+    }
+
+    function testSendWithholdingOnlyDistributor() public {
+        bytes32 withholdingId = keccak256("withholding-3");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, user, distribution.DISTRIBUTOR_ROLE()
+            )
+        );
+        vm.prank(user);
+        distribution.sendWithholding(address(dshareToken), 200e18, withholder, withholdingId);
+    }
+
+    function testSendWithholdingZeroChecks() public {
+        bytes32 withholdingId = keccak256("withholding-4");
+        uint256 amount = 200e18;
+
+        vm.expectRevert(DividendDistribution.ZeroAddress.selector);
+        vm.prank(distributor);
+        distribution.sendWithholding(address(0), amount, withholder, withholdingId);
+
+        vm.expectRevert(DividendDistribution.ZeroAddress.selector);
+        vm.prank(distributor);
+        distribution.sendWithholding(address(dshareToken), amount, address(0), withholdingId);
+
+        vm.expectRevert(DividendDistribution.ZeroAmount.selector);
+        vm.prank(distributor);
+        distribution.sendWithholding(address(dshareToken), 0, withholder, withholdingId);
+    }
+
+    // ------------------- sendFee Tests ------------------- //
+
+    function testSendFee() public {
+        bytes32 brokerageDividendId = keccak256("brokerage-dividend-fee-1");
+        uint256 totalAmount = 5000e18;
+        vm.prank(distributor);
+        distribution.mintDividend(address(dshareToken), totalAmount, address(distribution), brokerageDividendId);
+
+        bytes32 feeId = keccak256("fee-1");
+        uint256 feeAmount = 50e18;
+
+        vm.expectEmit(true, true, true, true);
+        emit FeeSent(feeId, revenueVault, address(dshareToken), feeAmount);
+
+        vm.prank(distributor);
+        distribution.sendFee(address(dshareToken), feeAmount, revenueVault, feeId);
+
+        assertEq(dshareToken.balanceOf(revenueVault), feeAmount);
+        assertTrue(distribution.feeSent(feeId));
+    }
+
+    function testSendFeeIdempotency() public {
+        bytes32 brokerageDividendId = keccak256("brokerage-dividend-fee-2");
+        vm.prank(distributor);
+        distribution.mintDividend(address(dshareToken), 5000e18, address(distribution), brokerageDividendId);
+
+        bytes32 feeId = keccak256("fee-2");
+        uint256 feeAmount = 50e18;
+
+        vm.prank(distributor);
+        distribution.sendFee(address(dshareToken), feeAmount, revenueVault, feeId);
+
+        vm.expectRevert(abi.encodeWithSelector(DividendDistribution.FeeAlreadySent.selector, feeId));
+        vm.prank(distributor);
+        distribution.sendFee(address(dshareToken), feeAmount, revenueVault, feeId);
+    }
+
+    function testSendFeeOnlyDistributor() public {
+        bytes32 feeId = keccak256("fee-3");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, user, distribution.DISTRIBUTOR_ROLE()
+            )
+        );
+        vm.prank(user);
+        distribution.sendFee(address(dshareToken), 50e18, revenueVault, feeId);
+    }
+
+    function testSendFeeZeroChecks() public {
+        bytes32 feeId = keccak256("fee-4");
+        uint256 feeAmount = 50e18;
+
+        vm.expectRevert(DividendDistribution.ZeroAddress.selector);
+        vm.prank(distributor);
+        distribution.sendFee(address(0), feeAmount, revenueVault, feeId);
+
+        vm.expectRevert(DividendDistribution.ZeroAddress.selector);
+        vm.prank(distributor);
+        distribution.sendFee(address(dshareToken), feeAmount, address(0), feeId);
+
+        vm.expectRevert(DividendDistribution.ZeroAmount.selector);
+        vm.prank(distributor);
+        distribution.sendFee(address(dshareToken), 0, revenueVault, feeId);
+    }
+
+    // ------------------- Full Omnibus Flow Test ------------------- //
+
+    function testFullOmnibusFlow() public {
+        // Step 1: Mint total dividend to contract
+        bytes32 brokerageDividendId = keccak256("omnibus-dividend-1");
+        uint256 totalAmount = 10000e18;
+
+        vm.prank(distributor);
+        distribution.mintDividend(address(dshareToken), totalAmount, address(distribution), brokerageDividendId);
+        assertEq(dshareToken.balanceOf(address(distribution)), totalAmount);
+
+        // Step 2: Send distributions to users
+        bytes32 dist1 = keccak256("dist-user1");
+        bytes32 dist2 = keccak256("dist-user2");
+        uint256 user1Amount = 3000e18;
+        uint256 user2Amount = 4000e18;
+
+        vm.startPrank(distributor);
+        distribution.sendDistribution(address(dshareToken), user1Amount, user, dist1);
+        distribution.sendDistribution(address(dshareToken), user2Amount, user2, dist2);
+
+        // Step 3: Send withholding
+        bytes32 whId = keccak256("wh-user1");
+        uint256 withholdingAmount = 500e18;
+        distribution.sendWithholding(address(dshareToken), withholdingAmount, withholder, whId);
+
+        // Step 4: Send fee
+        bytes32 feeId = keccak256("fee-omnibus");
+        uint256 feeAmount = 100e18;
+        distribution.sendFee(address(dshareToken), feeAmount, revenueVault, feeId);
+        vm.stopPrank();
+
+        // Verify final balances
+        assertEq(dshareToken.balanceOf(user), user1Amount);
+        assertEq(dshareToken.balanceOf(user2), user2Amount);
+        assertEq(dshareToken.balanceOf(withholder), withholdingAmount);
+        assertEq(dshareToken.balanceOf(revenueVault), feeAmount);
+        assertEq(
+            dshareToken.balanceOf(address(distribution)),
+            totalAmount - user1Amount - user2Amount - withholdingAmount - feeAmount
+        );
     }
 }

--- a/test/DividendDistribution.t.sol
+++ b/test/DividendDistribution.t.sol
@@ -7,10 +7,21 @@ import "solady/test/utils/mocks/MockERC20.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {IAccessControl} from "openzeppelin-contracts/contracts/access/IAccessControl.sol";
 import {ERC1967Proxy} from "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IDShare} from "../src/IDShare.sol";
+
+/// @notice Mock DShare token for testing mint functionality
+contract MockDShare is MockERC20 {
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) MockERC20(name_, symbol_, decimals_) {}
+
+    function mint(address to, uint256 value) public override {
+        _mint(to, value);
+    }
+}
 
 contract DividendDistributionTest is Test {
     DividendDistribution distribution;
     MockERC20 token;
+    MockDShare dshareToken;
 
     uint256 public userPrivateKey;
     uint256 public user2PrivateKey;
@@ -20,6 +31,7 @@ contract DividendDistributionTest is Test {
     address public user2;
     address public admin;
     address public distributor = address(4);
+    address public withholder = address(5);
 
     struct HashAndDataTuple {
         uint256 originalData;
@@ -32,6 +44,12 @@ contract DividendDistributionTest is Test {
         uint256 indexed distributionId, uint256 totalDistribution, uint256 startDate, uint256 endDate
     );
     event DistributionReclaimed(uint256 indexed distributionId, uint256 totalReclaimed);
+    event DistributionMinted(
+        bytes32 indexed distributionFillId, address indexed recipient, address indexed token, uint256 amount
+    );
+    event WithholdingMinted(
+        bytes32 indexed distributionWithholdingId, address indexed recipient, address indexed token, uint256 amount
+    );
 
     function setUp() public {
         userPrivateKey = 0x01;
@@ -43,6 +61,7 @@ contract DividendDistributionTest is Test {
 
         vm.startPrank(admin);
         token = new MockERC20("Money", "$", 6);
+        dshareToken = new MockDShare("DShare", "DS", 18);
         DividendDistribution distributionImpl = new DividendDistribution();
         distribution = DividendDistribution(
             address(
@@ -177,5 +196,127 @@ contract DividendDistributionTest is Test {
 
         assertEq(IERC20(address(token)).balanceOf(address(distribution)), 0);
         assertEq(IERC20(address(token)).balanceOf(distributor), totalDistribution);
+    }
+
+    // ------------------- mintDistribution Tests ------------------- //
+
+    function testMintDistribution() public {
+        bytes32 fillId = keccak256("unique-fill-id-1");
+        uint256 amount = 1000e18;
+
+        vm.expectEmit(true, true, true, true);
+        emit DistributionMinted(fillId, user, address(dshareToken), amount);
+
+        vm.prank(distributor);
+        distribution.mintDistribution(address(dshareToken), amount, user, fillId);
+
+        assertEq(dshareToken.balanceOf(user), amount);
+        assertTrue(distribution.distributionFilled(fillId));
+    }
+
+    function testMintDistributionIdempotency() public {
+        bytes32 fillId = keccak256("unique-fill-id-2");
+        uint256 amount = 1000e18;
+
+        vm.prank(distributor);
+        distribution.mintDistribution(address(dshareToken), amount, user, fillId);
+
+        vm.expectRevert(abi.encodeWithSelector(DividendDistribution.DistributionAlreadyFilled.selector, fillId));
+        vm.prank(distributor);
+        distribution.mintDistribution(address(dshareToken), amount, user, fillId);
+    }
+
+    function testMintDistributionOnlyDistributor() public {
+        bytes32 fillId = keccak256("unique-fill-id-3");
+        uint256 amount = 1000e18;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, user, distribution.DISTRIBUTOR_ROLE()
+            )
+        );
+        vm.prank(user);
+        distribution.mintDistribution(address(dshareToken), amount, user, fillId);
+    }
+
+    function testMintDistributionZeroChecks() public {
+        bytes32 fillId = keccak256("unique-fill-id-4");
+        uint256 amount = 1000e18;
+
+        // Test zero token address
+        vm.expectRevert(DividendDistribution.ZeroAddress.selector);
+        vm.prank(distributor);
+        distribution.mintDistribution(address(0), amount, user, fillId);
+
+        // Test zero recipient address
+        vm.expectRevert(DividendDistribution.ZeroAddress.selector);
+        vm.prank(distributor);
+        distribution.mintDistribution(address(dshareToken), amount, address(0), fillId);
+
+        // Test zero amount
+        vm.expectRevert(DividendDistribution.ZeroAmount.selector);
+        vm.prank(distributor);
+        distribution.mintDistribution(address(dshareToken), 0, user, fillId);
+    }
+
+    // ------------------- mintWithholding Tests ------------------- //
+
+    function testMintWithholding() public {
+        bytes32 withholdingId = keccak256("unique-withholding-id-1");
+        uint256 amount = 500e18;
+
+        vm.expectEmit(true, true, true, true);
+        emit WithholdingMinted(withholdingId, withholder, address(dshareToken), amount);
+
+        vm.prank(distributor);
+        distribution.mintWithholding(address(dshareToken), amount, withholder, withholdingId);
+
+        assertEq(dshareToken.balanceOf(withholder), amount);
+        assertTrue(distribution.withholdingFilled(withholdingId));
+    }
+
+    function testMintWithholdingIdempotency() public {
+        bytes32 withholdingId = keccak256("unique-withholding-id-2");
+        uint256 amount = 500e18;
+
+        vm.prank(distributor);
+        distribution.mintWithholding(address(dshareToken), amount, withholder, withholdingId);
+
+        vm.expectRevert(abi.encodeWithSelector(DividendDistribution.WithholdingAlreadyFilled.selector, withholdingId));
+        vm.prank(distributor);
+        distribution.mintWithholding(address(dshareToken), amount, withholder, withholdingId);
+    }
+
+    function testMintWithholdingOnlyDistributor() public {
+        bytes32 withholdingId = keccak256("unique-withholding-id-3");
+        uint256 amount = 500e18;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, user, distribution.DISTRIBUTOR_ROLE()
+            )
+        );
+        vm.prank(user);
+        distribution.mintWithholding(address(dshareToken), amount, withholder, withholdingId);
+    }
+
+    function testMintWithholdingZeroChecks() public {
+        bytes32 withholdingId = keccak256("unique-withholding-id-4");
+        uint256 amount = 500e18;
+
+        // Test zero token address
+        vm.expectRevert(DividendDistribution.ZeroAddress.selector);
+        vm.prank(distributor);
+        distribution.mintWithholding(address(0), amount, withholder, withholdingId);
+
+        // Test zero recipient address
+        vm.expectRevert(DividendDistribution.ZeroAddress.selector);
+        vm.prank(distributor);
+        distribution.mintWithholding(address(dshareToken), amount, address(0), withholdingId);
+
+        // Test zero amount
+        vm.expectRevert(DividendDistribution.ZeroAmount.selector);
+        vm.prank(distributor);
+        distribution.mintWithholding(address(dshareToken), 0, withholder, withholdingId);
     }
 }


### PR DESCRIPTION
### Ticket

[Please link any jira tickets, docs or other relevant context.](https://linear.app/dinaricrypto/issue/DSHARE-2828/add-new-dividend-smart-contract-functions)

### Description

**mintDividend**
  - Takes in token address, token amount, target address, brokerageDividendId as idempotency key
  - Mints vUSD or DShare directly to target address (contract itself for omnibus brokerage, or user wallet for individual brokerage)
  - Emits DividendMinted event with brokerageDividendId, target, token, and amount

  **sendDistribution**
  - Takes in token address, token amount, recipient address, distributionId as idempotency key
  - Transfers tokens from contract balance to recipient
  - Emits DistributionSent event with distributionId, recipient, token, and amount

  **sendWithholding**
  - Takes in token address, token amount, recipient address, withholdingId as idempotency key
  - Transfers tokens from contract balance to withholding recipient
  - Emits WithholdingSent event with withholdingId, recipient, token, and amount

  **sendFee**
  - Takes in token address, token amount, recipient address, feeId as idempotency key
  - Transfers tokens from contract balance to revenue vault
  - Emits FeeSent event with feeId, recipient, token, and amount

### Tests

What tests scenarios did you perform? Provide relevant screenshot/recordings here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new minting and token-transfer entrypoints in a distributor-authorized contract; mistakes could lead to unintended token issuance or payouts despite idempotency and role checks.
> 
> **Overview**
> Adds new DISTRIBUTOR-only dividend payout primitives to `DividendDistribution`: `mintDividend` (mints via `IDShare.mint`) and `sendDistribution`/`sendWithholding`/`sendFee` (transfer tokens from contract balance), each emitting new events and guarded by new idempotency mappings with dedicated revert errors and zero-value/address checks.
> 
> Bumps the upgradeable contract `version()`/`publicVersion()` to `2`/`2.0.0`, updates `IDividendDistributor` to expose the new functions, and expands `DividendDistribution.t.sol` with a mock mintable `DShare` plus coverage for happy paths, access control, idempotency, and an end-to-end omnibus flow. Also adds a `profile.ci` section to `foundry.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21a6ca7a475f76de7872158ff81a37921eb223ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->